### PR TITLE
fix(build): reload after submit

### DIFF
--- a/companions/build/ui.ts
+++ b/companions/build/ui.ts
@@ -73,8 +73,7 @@ export async function renderPage(_ctx: CompanionContext): Promise<string> {
           const desc = document.getElementById('desc').value.trim();
           if (!desc) return;
           await api('POST', '/api/c/build/requests', { description: desc });
-          document.getElementById('desc').value = '';
-          showToast('Request submitted');
+          location.reload();
         });
         sse.addEventListener('build.request_created', () => location.reload());
         sse.addEventListener('build.request_updated', () => location.reload());


### PR DESCRIPTION
## Summary
- Build UI listens for a `build.request_created` SSE event to refresh, but nothing emits it — the HTTP POST handler in `src/helpers/requestStore.ts#buildRouter()` has no broadcaster reference
- Short-term fix: `location.reload()` after the fetch resolves (optimistic; single-user localhost, so fine)
- Proper fix (follow-up): thread the broadcaster into `createRequestStore` so the router can emit `build.request_created`

## Test plan
- [ ] `npm run check` clean
- [ ] `npm test` 35/35 pass
- [ ] Manual: submit a description in the Build form — the request card appears without a manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)