### PR TITLE
Scaffold foundation: preflight, error helpers, BaseArtifact, About page, write-action safety

### DIFF
--- a/companions/build/pages/Detail.tsx
+++ b/companions/build/pages/Detail.tsx
@@ -19,7 +19,6 @@ export default function BuildDetail({ entity }: { entity: Entity<BuildInput, Bui
           {check(a.smokeTestPassed)} <span style={{ fontSize: 13 }}>smoke test</span>
         </div>
       </div>
-      {a.summary && <p style={{ fontSize: 14, margin: 0 }}>{a.summary}</p>}
       {a.filesCreated.length > 0 && (
         <div>
           <div style={{ fontSize: 12, color: "var(--muted)", marginBottom: 4 }}>Files created</div>

--- a/companions/build/templates/entity/server/tools.ts
+++ b/companions/build/templates/entity/server/tools.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { CompanionToolDefinition } from "../../../src/shared/types.js";
-import { successResult, errorResult } from "../../../src/shared/types.js";
+import { successResult, errorResult, configErrorResult, transientErrorResult } from "../../../src/shared/types.js";
 
 // Domain proxy tools for __NAME__.
 //
@@ -9,24 +9,42 @@ import { successResult, errorResult } from "../../../src/shared/types.js";
 // _update_status, _append_log, _save_artifact, _fail) — don't add them here.
 //
 // Every tool name must be prefixed "__NAME___".
+// Set sideEffect: "write" on tools that change external state — the skill
+// will require user permission before each call.
 
 export const tools: CompanionToolDefinition[] = [
-  // Replace this example with your actual external API calls:
+  // Read-only example (sideEffect defaults to "read"):
   //
   // {
   //   name: "__NAME___fetch",
-  //   description:
-  //     "Fetch data from the external service. Called by the skill during Step 3a.",
+  //   description: "Fetch data from the external service.",
   //   schema: {
   //     id: z.string().describe("entity ID"),
   //     query: z.string().describe("query to send to the external API"),
   //   },
   //   async handler({ id, query }: { id: string; query: string }) {
-  //     // Call your external API here with locally-stored credentials.
-  //     // e.g. AWS SDK, GitHub API client, Linear SDK, etc.
-  //     // return successResult(data)  on success
-  //     // return errorResult(message) on failure — lets the skill call _fail
-  //     return errorResult("not implemented — replace with a real API call");
+  //     const token = process.env.SERVICE_TOKEN;
+  //     if (!token) return configErrorResult("SERVICE_TOKEN", "create a token at example.com/tokens");
+  //     try {
+  //       const data = await fetch("https://api.example.com/...").then((r) => r.json());
+  //       return successResult(data);
+  //     } catch (err: any) {
+  //       if (err.code === "ECONNREFUSED") return transientErrorResult(`network error: ${err.message}`);
+  //       return errorResult(`API error: ${err.message}`);
+  //     }
+  //   },
+  // },
+  //
+  // Write example (sideEffect: "write" — skill prompts for permission):
+  //
+  // {
+  //   name: "__NAME___create",
+  //   description: "Create a new resource. Visible to other users; cannot be deleted.",
+  //   schema: { id: z.string(), title: z.string() },
+  //   sideEffect: "write",
+  //   async handler({ id, title }: { id: string; title: string }) {
+  //     // ... call API
+  //     return successResult({ ok: true });
   //   },
   // },
 ];

--- a/companions/build/templates/skill.md
+++ b/companions/build/templates/skill.md
@@ -22,20 +22,45 @@ mcp__claudepanion__`__NAME___get`({ id: "<entity-id>" })
 
 If the call errors or the entity is missing, stop.
 
-## Step 2 — Mark running
+### Step 1.5 — Detect continuation
+
+If `entity.artifact !== null`, this is a continuation — the user clicked "Continue" on a previously completed run. Read the prior artifact carefully before doing new work. Use updated `entity.input` fields as the user's redirection. Log:
+
+```
+mcp__claudepanion__`__NAME___append_log`({ id: "<entity-id>", message: "Continuing from prior run — reading previous artifact" })
+```
+
+Produce a complete, updated artifact when you save (not a diff).
+
+## Step 2 — Preflight check
+
+Verify the companion's required env vars are set:
+
+```bash
+curl -s http://localhost:3001/api/companions/__NAME__/preflight
+```
+
+If the response shows `missingRequired` non-empty:
+
+```
+mcp__claudepanion__`__NAME___fail`({ id: "<entity-id>", errorMessage: "[config] missing env vars: <list>" })
+```
+
+and stop.
+
+## Step 3 — Mark running
 
 ```
 mcp__claudepanion__`__NAME___update_status`({ id: "<entity-id>", status: "running", statusMessage: "starting" })
 ```
 
-## Step 3 — Do the work
+## Step 4 — Do the work
 
 __DESCRIPTION__
 
-### 3a — Call domain proxy tools for external system access
+### 4a — Call domain proxy tools for external system access
 
-If this companion has domain proxy tools (defined in `companions/__NAME__/server/tools.ts`),
-call them to access external systems. These are your primary data source.
+If this companion has domain proxy tools (defined in `companions/__NAME__/server/tools.ts`), call them to access external systems. These are your primary data source.
 
 ```
 mcp__claudepanion__`__NAME___<verb>`({ id: "<entity-id>", ... })
@@ -47,7 +72,7 @@ After each proxy tool call, log what you received:
 mcp__claudepanion__`__NAME___append_log`({ id: "<entity-id>", message: "fetched 47 records from <source>" })
 ```
 
-### 3b — Use Claude's built-in tools for local work (if needed)
+### 4b — Use Claude's built-in tools for local work (optional)
 
 Use Read, Grep, Bash, and Edit for local file or repository access.
 
@@ -58,24 +83,68 @@ mcp__claudepanion__`__NAME___append_log`({ id: "<entity-id>", message: "<what yo
 mcp__claudepanion__`__NAME___update_status`({ id: "<entity-id>", status: "running", statusMessage: "<current phase>" })
 ```
 
-## Step 4 — Save the artifact
+### 4c — Write actions require user permission
 
-When the work produces a result, save it. The artifact shape is defined by `__PASCAL__Artifact` in `companions/__NAME__/types.ts`:
+If a proxy tool has `sideEffect: "write"` (changes state in an external system), you MUST ask the user before calling it:
+
+1. Show the proposed write content in chat ("Here's the review I'd post to GitHub: …")
+2. Ask: "Should I post this?"
+3. Wait for confirmation
+4. Only call the write tool if confirmed
+5. If declined, save the artifact with `errors: ["user declined write action"]` and proceed to Step 5
+
+Never call a write tool without explicit user permission.
+
+## Step 5 — Save the artifact
+
+The artifact shape is defined by `__PASCAL__Artifact` in `companions/__NAME__/types.ts`. It extends `BaseArtifact` so it may include `summary?: string` and `errors?: string[]`:
 
 ```
 mcp__claudepanion__`__NAME___save_artifact`({
   id: "<entity-id>",
-  artifact: { summary: "<one or two sentences describing the result>" }
+  artifact: {
+    summary: "<one-line outcome>",
+    errors: [<any [recoverable] errors logged during the run>],
+    // ... your custom artifact fields
+  }
 })
 ```
 
-## Step 5 — Complete
+## Step 6 — Complete
 
 ```
 mcp__claudepanion__`__NAME___update_status`({ id: "<entity-id>", status: "completed" })
 ```
 
-## On error at any step
+## Error handling
+
+When a proxy tool returns an error, branch on the prefix:
+
+| Prefix | Action |
+|---|---|
+| `[config]` | Call `__NAME___fail` with the error message and stop |
+| `[input]` | Call `__NAME___fail` with the error message and stop |
+| `[transient]` | Log warn, retry the tool ONCE; if still failing, call `__NAME___fail` |
+| `[recoverable]` | Log warn, continue; add the message to the artifact's `errors[]` field |
+| (no prefix) | Treat as fatal: call `__NAME___fail` |
+
+For example:
+
+```
+const result = mcp__claudepanion__`__NAME___fetch_thing`({...})
+if (result.isError) {
+  if (result.content[0].text.startsWith("[transient]")) {
+    // log warn, retry once
+  } else if (result.content[0].text.startsWith("[recoverable]")) {
+    // log warn, add to artifact.errors, continue
+  } else {
+    mcp__claudepanion__`__NAME___fail`({ id, errorMessage: result.content[0].text })
+    // stop
+  }
+}
+```
+
+## On unrecoverable error at any step
 
 ```
 mcp__claudepanion__`__NAME___fail`({ id: "<entity-id>", errorMessage: "<short cause>", errorStack: "<optional stack>" })

--- a/companions/build/types.ts
+++ b/companions/build/types.ts
@@ -1,3 +1,5 @@
+import type { BaseArtifact } from "../../src/shared/types.js";
+
 export type BuildInput =
   | {
       mode: "new-companion";
@@ -13,9 +15,10 @@ export type BuildInput =
       description: string;
     };
 
-export interface BuildArtifact {
+export interface BuildArtifact extends BaseArtifact {
   filesCreated: string[];
   filesModified: string[];
+  /** Required for Build runs (overrides BaseArtifact's optional summary). */
   summary: string;
   validatorPassed: boolean;
   smokeTestPassed: boolean;

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -44,6 +44,33 @@ Each of these is a named gap from comparing the shipped state to `docs/concept.m
 
 5. **Smoke runs tool callability, not headless render.** Vision's Build reliability section #3 wanted "load the companion and render its pages headlessly." Spec pivoted to tool-smoke; both defensible. If rendering-smoke lands later it becomes a separate check alongside the current one.
 
+## Handoff UX — making the Claude Code step feel like summoning a companion
+
+The slash command handoff (form → pending state → paste into Claude Code) is load-bearing and intentional — it's the moment the user delegates to Claude with permission and context. But it currently reads like a technical instruction rather than an invitation. The framing should match the name: you're calling on a companion, not running a job.
+
+**Why the handoff is the right model (don't remove it):**
+- It's the permission grant — the user chooses when and where Claude operates.
+- Interactive mid-run — Claude can ask clarifying questions; headless API calls can't.
+- Local tool access — Read/Write/Bash/Edit only exist in a Claude Code session.
+- The name "claudepanion" only makes sense if Claude is present. A background process isn't a companion.
+
+**Improvements to the pending state:**
+- Replace generic copy with a one-line summary of what Claude is about to do based on the form input. e.g. *"Claude will review PR #142 in myorg/myrepo, read the diff, and post a structured review."*
+- Add a short "what to expect" note: *"Claude will update this page as it works. Follow along here or interact with it in your terminal."*
+- Frame the slash command as an invitation, not a command: *"Your companion is ready. Open Claude Code in this repo and paste:"*
+
+**During the run:**
+- The live log tail is Claude narrating its work in real time — lean into that. "Claude is working…" not "running…".
+- Log messages from `_append_log` calls should read like a collaborator giving updates, not a system printing status codes.
+
+**The Continue flow:**
+- "Continue with Claude" after completion is a natural re-engagement point that already exists. Make it feel like picking the conversation back up, not re-submitting a form.
+
+**Future consideration — pure-proxy headless mode:**
+- A companion that only calls external API proxy tools (no Read/Write/Bash/Edit) could theoretically run headlessly via the Anthropic API without a Claude Code session. Worth exploring for a specific class of companions, but introduces a two-tier capability model. Don't pursue until there's a concrete use case that can't be served by the current flow.
+
+---
+
 ## Smaller polish items
 
 - Pulsing indicator on the running status pill.

--- a/docs/scaffold-spec.md
+++ b/docs/scaffold-spec.md
@@ -599,6 +599,23 @@ Conventions:
 - Optional `errors?: string[]` per §10d.
 - Should be JSON-serializable (no functions, no Dates — use ISO strings).
 
+### 11.5. The `BaseArtifact` interface
+
+Every companion's artifact type should extend `BaseArtifact`:
+
+```ts
+export interface BaseArtifact {
+  /** Short one-liner describing the run's outcome. Shown in List row + Detail header. */
+  summary?: string;
+  /** Recoverable issues during the run. Rendered as "Notes during this run" by the host. */
+  errors?: string[];
+}
+```
+
+The host wraps every Detail page renderer in `<BaseArtifactPanel>` which automatically renders `summary` (top banner) and `errors[]` (bottom section). Companion authors only render their domain-specific middle content.
+
+Companions can make `summary` required by overriding the type in the extended interface (e.g., `BuildArtifact.summary: string`).
+
 ### 11b. Detail rendering
 
 ```ts
@@ -811,34 +828,29 @@ This spec describes the target. Current state vs. spec:
 |---|---|
 | 2. Lifecycle | ✅ Shipped |
 | 3. Manifest (existing fields) | ✅ Shipped |
-| 3. Manifest `requiredEnv`/`optionalEnv` | 🎯 Not yet |
-| 4. Configuration & preflight | 🎯 Not yet |
-| 5. Form contract | ✅ Shipped (form mostly), 🎯 preflight banner |
+| 3. Manifest `requiredEnv`/`optionalEnv` | ✅ Shipped |
+| 4. Configuration & preflight | ✅ Shipped (endpoint + banner) |
+| 5. Form contract | ✅ Shipped (form + preflight banner integration) |
 | 6. Entity | ✅ Shipped |
-| 7. Skill template | ✅ Shipped (existing template), 🎯 preflight + error sections |
-| 7d. Continuation contract | ✅ Endpoint shipped, 🎯 skill template stanza |
+| 7. Skill template | ✅ Shipped (continuation + preflight + error handling + write-permission stanzas) |
+| 7d. Continuation contract | ✅ Shipped (skill template stanza) |
 | 8. Generic entity tools | ✅ Shipped (with proper Zod schemas after recent refactor) |
 | 9. `CompanionToolDefinition` | ✅ Shipped |
-| 9e. Write-action safety | 🎯 Not yet (conventions only, no helpers needed) |
-| 10. Error handling helpers | 🎯 Not yet (`configErrorResult`, `inputErrorResult`, `transientErrorResult`) |
-| 10. Skill error pattern | 🎯 Not yet (template additions) |
-| 10. Artifact `errors[]` convention | 🎯 Not yet (convention, no code change needed but docs to write) |
-| 11. Artifact rendering | ✅ Shipped |
+| 9e. Write-action safety | ✅ Shipped (sideEffect flag + skill pattern + About warning) |
+| 10. Error handling helpers | ✅ Shipped (configErrorResult/inputErrorResult/transientErrorResult) |
+| 10. Skill error pattern | ✅ Shipped (template additions) |
+| 10. Artifact `errors[]` convention | ✅ Shipped (BaseArtifact + BaseArtifactPanel) |
+| 11. Artifact rendering | ✅ Shipped (BaseArtifactPanel wrapper) |
+| 11.5. BaseArtifact interface | ✅ Shipped |
 | 12. List & Detail pages | ✅ Shipped |
-| 12c. About page (entity kind) | 🎯 Not yet — auto-generated `<CompanionAbout>` component |
+| 12c. About page (entity kind) | ✅ Shipped (CompanionAbout) |
 | 13. Registration | ✅ Shipped |
 | 13d. External dependencies | ✅ Convention documented (top-level for local, own pkg.json for installed) |
 | 14. Validator / smoke / watcher | ✅ Shipped (validator may need `requiredEnv` rule) |
 
-**Foundation work to land before chip examples:**
+**Foundation shipped:** Phase 1–4 of `docs/superpowers/plans/2026-04-25-scaffold-foundation.md` complete.
 
-1. Manifest `requiredEnv` / `optionalEnv` fields
-2. `GET /api/companions/:name/preflight` endpoint
-3. `<PreflightBanner />` form component + form integration
-4. Error helpers in `shared/types.ts`
-5. Skill template — preflight section + error handling section + continuation detection stanza
-6. `<CompanionAbout>` component (read-only / write-warning treatment)
-7. Build skill template — explicit read-only bias when interpreting vague descriptions
-8. Doc note on artifact `errors[]` convention
+**Remaining for chip examples:**
 
-That's a tight, focused PR before the first chip example lands.
+1. Build's first read-only proxy companion (e.g., GitHub PR reviewer) using the new primitives
+2. End-to-end verification — scaffold a companion with `requiredEnv`, run preflight check, verify About page rendering, simulate a run with a recoverable error

--- a/docs/scaffold-spec.md
+++ b/docs/scaffold-spec.md
@@ -1,0 +1,844 @@
+# Companion Scaffold Specification
+
+> **North-star spec.** This document describes what a claudepanion companion is, the primitives the host provides, and the contracts every companion must satisfy. Some sections describe the target state ahead of current implementation — those are flagged 🎯. The rest reflects shipped code.
+
+This is the developer reference for building companions. If you're scaffolding a new one, this is the contract you're writing against.
+
+---
+
+## 1. Overview
+
+A **companion** is a small app living inside the claudepanion host. The host provides a fixed set of primitives — form rendering, entity lifecycle, MCP tool registration, log streaming, artifact persistence, error reporting — and the companion fills in the domain-specific behavior.
+
+Two kinds of companion:
+
+| Kind | Description | Has lifecycle? | Has form? | Has artifact? |
+|---|---|---|---|---|
+| `entity` | Lifecycle-driven runs (form → pending → running → completed / error) | yes | yes | yes |
+| `tool` | Direct MCP tools, no lifecycle. Auto-generated About page with Try-it panel. | no | no | no |
+
+The rest of this spec focuses on `entity` companions, which are the primary kind. `tool` companions are a simpler subset.
+
+**The canonical interaction pattern (entity kind):**
+
+```
+FORM ──► ENTITY (pending) ──► CLAUDE CODE HANDOFF ──► GENERIC + PROXY TOOLS ──► ARTIFACT
+                  ▲                                           │
+                  └─────────── log tail / status morphs ──────┘
+```
+
+Each box in this pattern is a primitive the host provides. The companion declares the domain-specific shape of inputs, tools, and artifacts.
+
+---
+
+## 2. Companion Lifecycle
+
+Every entity moves through a four-state machine:
+
+```
+pending  ──►  running  ──►  completed
+              │
+              └──────►  error
+```
+
+| State | Meaning | UI surface |
+|---|---|---|
+| `pending` | Entity created, awaiting Claude Code handoff | Slash command + invitation copy |
+| `running` | Claude has started executing the skill | Live log tail, status pill, statusMessage |
+| `completed` | Skill finished, artifact saved | Artifact rendered via Detail page |
+| `error` | Unrecoverable failure | errorMessage + errorStack shown |
+
+Transitions are driven by the skill calling generic entity tools (`_update_status`, `_save_artifact`, `_fail`). The state itself lives in `data/<companion>/<id>.json`.
+
+Re-engagement: a `completed` entity can be flipped back to `pending` via `POST /api/entities/:id/continue`, preserving the prior artifact as context. The Detail page exposes this as a "Continue" action.
+
+---
+
+## 3. The Manifest
+
+Every companion ships a manifest at `companions/<name>/manifest.ts`:
+
+```ts
+export interface Manifest {
+  name: string;                          // slug, /^[a-z][a-z0-9-]*$/
+  kind: "entity" | "tool";
+  displayName: string;                   // shown in sidebar
+  icon: string;                          // emoji
+  description: string;                   // shown in About page
+  contractVersion: string;               // currently "1"
+  version: string;                       // semver
+
+  // 🎯 Configuration declarations
+  requiredEnv?: string[];                // companion is non-functional without these
+  optionalEnv?: string[];                // companion degrades gracefully without these
+}
+```
+
+The manifest is the companion's passport. The host reads it to:
+- Register the companion in the sidebar
+- Auto-generate the entity tools (`<name>_get`, etc.)
+- Validate config at startup (🎯 via `requiredEnv`)
+- Surface metadata to Claude (description used in tool docs)
+
+**Naming rule:** `name` is the canonical slug. All tool names must be prefixed `<name>_`. Imports/exports use camelCase derivative (`my-thing` → `myThing`). Type names use PascalCase derivative (`my-thing` → `MyThing`).
+
+---
+
+## 4. Configuration — `requiredEnv` & Preflight 🎯
+
+External-system companions need credentials. The host provides a generic mechanism so every companion's config story works the same way.
+
+### 4a. Declaring config dependencies
+
+```ts
+// companions/pr-reviewer/manifest.ts
+export const manifest: Manifest = {
+  name: "pr-reviewer",
+  // ...
+  requiredEnv: ["GITHUB_TOKEN"],
+  optionalEnv: [],
+};
+```
+
+`requiredEnv` is a hard gate: missing values mean the companion cannot run, and the form will not let the user submit.
+
+`optionalEnv` is a soft gate: missing values surface as a warning but the form still allows submission. Used for env vars that enable extra features (e.g., a Slack token that lets the companion also post results, but isn't required for the primary run).
+
+### 4b. The preflight endpoint
+
+The host exposes a generic preflight check:
+
+```
+GET /api/companions/:name/preflight
+→ {
+  ok: boolean,
+  missingRequired: string[],      // env vars from requiredEnv that aren't set
+  missingOptional: string[],      // env vars from optionalEnv that aren't set
+}
+```
+
+Any companion can be probed for config readiness without running it. This is the foundation of the form config banner and any future "self-diagnostic" UI.
+
+### 4c. Form integration
+
+When the form mounts:
+1. Call `GET /api/companions/<name>/preflight`
+2. If `missingRequired` is non-empty: render a blocking config banner. Disable submit. Show the env vars and (where the companion provides hints) how to set them.
+3. If `missingOptional` is non-empty: render a soft warning banner. Submit still works.
+
+Banner copy convention:
+
+> ⚠️ **GITHUB_TOKEN is not set.** This companion needs a GitHub personal access token with `repo` scope. [Set it in your environment](docs/path-to-doc.md) and reload this page.
+
+The host provides the banner component (`<PreflightBanner companion="<name>" />`) so every companion's banner looks and behaves the same way.
+
+### 4d. Runtime config check
+
+Even with a preflight banner, env vars can disappear (server restart, process env wiped). Proxy tool handlers should defensively check at call time and return `configErrorResult(envVar, hint?)` if missing — see §10.
+
+---
+
+## 5. The Form
+
+A companion declares its input shape and form UI.
+
+### 5a. Input type
+
+```ts
+// companions/<name>/types.ts
+export interface PrReviewerInput {
+  repo: string;                  // "owner/repo"
+  prNumber: number;
+  focus?: string;                // optional review focus
+}
+```
+
+The input type is the contract between the form and the skill — what the form submits is what `_get` returns to Claude.
+
+### 5b. Form component
+
+```ts
+// companions/<name>/form.tsx
+type CompanionForm = ComponentType<{
+  onSubmit: (input: unknown) => void | Promise<void>;
+}>;
+```
+
+The form renders inputs, validates client-side, and calls `onSubmit` with a fully shaped `PrReviewerInput`. The host's `NewEntity` page wires this to `POST /api/entities`.
+
+**Form responsibilities:**
+- Render the inputs the companion needs
+- Client-side validation (required fields, format checks)
+- Call `onSubmit(input)` with a typed payload
+- 🎯 Render the preflight banner above the form when config is missing (host provides the component)
+
+**Form does NOT:**
+- Issue MCP calls
+- Talk to external systems directly (the skill does this via proxy tools)
+- Persist anything (the entity store is the persistence layer)
+
+### 5c. Form registration
+
+Forms are registered in `companions/client.ts`:
+
+```ts
+import PrReviewerForm from "./pr-reviewer/form";
+const forms: Record<string, CompanionForm> = {
+  "pr-reviewer": PrReviewerForm as CompanionForm,
+};
+```
+
+Host's `getForm(name)` looks up the form for the New Entity route.
+
+---
+
+## 6. The Entity
+
+The entity is the durable state object. Every run produces exactly one entity.
+
+```ts
+export interface Entity<Input = unknown, Artifact = unknown> {
+  id: string;                          // <name>-abc123
+  companion: string;                   // companion slug
+  status: "pending" | "running" | "completed" | "error";
+  statusMessage: string | null;        // short progress note
+  createdAt: string;                   // ISO 8601
+  updatedAt: string;                   // ISO 8601
+  input: Input;                        // typed per companion
+  artifact: Artifact | null;           // typed per companion
+  errorMessage: string | null;
+  errorStack: string | null;
+  logs: LogEntry[];                    // live tail
+}
+
+export interface LogEntry {
+  timestamp: string;
+  level: "info" | "warn" | "error";
+  message: string;
+}
+```
+
+Stored as one JSON file per entity at `data/<companion>/<id>.json`. The same shape is read by both:
+- the UI (via REST: `GET /api/entities/:id?companion=<name>`)
+- the skill (via MCP: `<name>_get`)
+
+**Two bright lines:**
+- The UI reads via REST (read-mostly, polled every 2s).
+- The skill writes via MCP (write-mostly, one tool call at a time).
+
+Both touch the same JSON file. Concurrent writes are rare (single-user localhost).
+
+---
+
+## 7. The Skill
+
+The skill is the program Claude executes. It lives at `skills/<name>-companion/SKILL.md` (nested, literal `SKILL.md`).
+
+### 7a. Skill frontmatter
+
+```yaml
+---
+name: pr-reviewer-companion
+description: Use when the user pastes "/pr-reviewer-companion <entity-id>" — runs the PR reviewer companion against a GitHub PR.
+argument-hint: <entity-id>
+---
+```
+
+| Field | Purpose |
+|---|---|
+| `name` | Becomes the slash command (`/pr-reviewer-companion`) |
+| `description` | Read by Claude's router to decide when the skill applies |
+| `argument-hint` | UI placeholder when the user types the slash command |
+
+### 7b. Skill body — the standard structure
+
+The skill body is markdown. Every entity-kind skill follows this structure:
+
+```markdown
+# /<name>-companion <entity-id>
+
+> **CRITICAL — MCP tools ONLY:**
+> - All state changes go through mcp__claudepanion__<name>_* tools.
+> - NEVER curl /api/entities/* to mutate state.
+> - NEVER edit data/<name>/<id>.json directly.
+> - On any unrecoverable error, call mcp__claudepanion__<name>_fail and stop.
+
+## Step 1 — Load entity
+mcp__claudepanion__<name>_get({ id: "<entity-id>" })
+
+## Step 2 — Preflight check 🎯
+[Host-provided pattern — see §10c]
+
+## Step 3 — Mark running
+mcp__claudepanion__<name>_update_status({ id, status: "running", statusMessage: "starting" })
+
+## Step 4 — Do the work
+### 4a — Domain proxy tools
+[Companion-specific — call mcp__claudepanion__<name>_<verb> proxy tools]
+
+### 4b — Local tools (optional)
+[Use Claude's Read/Grep/Bash/Edit when local context is needed]
+
+## Step 5 — Save artifact
+mcp__claudepanion__<name>_save_artifact({ id, artifact: { ...shape... } })
+
+## Step 6 — Complete
+mcp__claudepanion__<name>_update_status({ id, status: "completed" })
+
+## Error handling 🎯
+[Standard pattern — see §10b]
+```
+
+The host provides this as a template at `companions/build/templates/skill.md`. Per-chip variations live at `companions/build/templates/skill-examples/<slug>.md`.
+
+### 7c. The `$ARGUMENTS` token
+
+Claude Code substitutes `$ARGUMENTS` in the skill body with whatever the user typed after the slash command. By convention, that's the entity ID — `pr-reviewer-abc123`.
+
+### 7d. The continuation contract 🎯
+
+A `completed` entity can be flipped back to `pending` via the Continue action (`POST /api/entities/:id/continue`). The same skill is invoked again with the same entity ID, but the entity now carries the prior artifact as context.
+
+**How the skill detects continuation:**
+
+```
+const entity = mcp_call("<name>_get", { id })
+const isContinuation = entity.artifact !== null
+```
+
+**On continuation, the skill must:**
+
+1. Log: *"Continuing from prior run — reading previous artifact"*
+2. Read `entity.artifact` carefully before doing new work
+3. Treat any updated input fields as the user's redirection — they're saying "do this differently this time"
+4. Produce a **complete, updated artifact** (not a diff). The prior artifact is replaced when `_save_artifact` is called again.
+
+**On fresh run** (no prior artifact): standard execution flow.
+
+The continuation pattern enables iteration without losing context: a user can review an artifact, click Continue with revised input, and Claude picks up with full context of the prior result. This is the natural re-engagement primitive — leaning on it makes companions feel like ongoing relationships rather than one-shot scripts.
+
+The skill template ships with a "Step 1.5 — Detect continuation" stanza pre-filled.
+
+---
+
+## 8. Generic Entity Tools
+
+The host auto-registers six MCP tools per entity companion. These are infrastructure — not declared by the companion.
+
+| Tool | Purpose | Signature |
+|---|---|---|
+| `<name>_get` | Load the entity | `{ id }` |
+| `<name>_list` | List entities, optionally filtered by status | `{ status? }` |
+| `<name>_update_status` | Transition state, optionally with statusMessage | `{ id, status, statusMessage? }` |
+| `<name>_append_log` | Append to logs[] (UI updates within 2s) | `{ id, message, level? }` |
+| `<name>_save_artifact` | Save the artifact | `{ id, artifact }` |
+| `<name>_fail` | Flip to error state | `{ id, errorMessage, errorStack? }` |
+
+Each is a `CompanionToolDefinition` with proper Zod schema and description — Claude reads parameter docs directly from the MCP registration.
+
+**Companions never override these.** If a companion needs different state-update semantics, that's a sign of a design problem.
+
+---
+
+## 9. Domain Proxy Tools
+
+The whole point of claudepanion. Every entity companion that's not just a structured-chat wrapper has these.
+
+### 9a. The `CompanionToolDefinition` interface
+
+```ts
+export interface CompanionToolDefinition<
+  TParams extends Record<string, unknown> = Record<string, unknown>
+> {
+  name: string;                        // must start with "<companion>_"
+  description: string;                 // shown to Claude in MCP tool docs
+  schema: z.ZodRawShape;               // Zod params, validated at runtime
+  handler: (params: TParams) => Promise<McpToolResult>;
+}
+```
+
+A proxy tool is a typed object, not a class. The handler is a plain async function.
+
+### 9b. The `McpToolResult` return type
+
+```ts
+export interface McpToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: true;
+  [key: string]: unknown;              // index signature for MCP SDK compat
+}
+
+export function successResult(data: unknown): McpToolResult;
+export function errorResult(message: string): McpToolResult;
+```
+
+Every handler returns one of these. `successResult(data)` JSON-stringifies non-string data; `errorResult(message)` flips `isError: true` so Claude sees the failure.
+
+### 9c. Where proxy tools live
+
+```
+companions/<name>/server/tools.ts
+  → exports: CompanionToolDefinition[]
+```
+
+The host scans this array, adds the tools to the MCP registry, registers them with the SDK using their `description` and `z.object(schema)`. No manual MCP wiring per companion.
+
+### 9d. Pattern: an external API call
+
+```ts
+import { z } from "zod";
+import { Octokit } from "@octokit/rest";
+import type { CompanionToolDefinition } from "../../../src/shared/types.js";
+import { successResult, configErrorResult, transientErrorResult, errorResult } from "../../../src/shared/types.js";
+
+export const tools: CompanionToolDefinition[] = [
+  {
+    name: "pr_reviewer_get_diff",
+    description: "Fetch the unified diff for a GitHub PR.",
+    schema: {
+      repo: z.string().describe('owner/repo, e.g. "sean1588/claudepanion"'),
+      prNumber: z.number().int().positive().describe("PR number"),
+    },
+    async handler({ repo, prNumber }: { repo: string; prNumber: number }) {
+      const token = process.env.GITHUB_TOKEN;
+      if (!token) return configErrorResult("GITHUB_TOKEN", "create a personal access token with 'repo' scope");
+
+      const [owner, name] = repo.split("/");
+      if (!owner || !name) return errorResult(`[input] repo must be "owner/repo", got "${repo}"`);
+
+      try {
+        const gh = new Octokit({ auth: token });
+        const { data } = await gh.pulls.get({
+          owner, repo: name, pull_number: prNumber,
+          mediaType: { format: "diff" },
+        });
+        return successResult(data);
+      } catch (err: any) {
+        if (err.status === 404) return errorResult(`[input] PR not found: ${repo}#${prNumber}`);
+        if (err.status === 401) return configErrorResult("GITHUB_TOKEN", "token is invalid or expired");
+        if (err.status === 403) return transientErrorResult(`GitHub rate limit or permission denied: ${err.message}`);
+        if (err.status >= 500) return transientErrorResult(`GitHub server error: ${err.message}`);
+        return errorResult(`GitHub API error: ${err.message}`);
+      }
+    },
+  },
+];
+```
+
+The pattern: validate config → validate input → call the API → classify any error → return.
+
+### 9e. Write-action safety 🎯
+
+Some companions have **write tools** — proxy tools that change state in external systems. Posting a PR review, updating a Linear issue, sending a Slack message, creating an AWS resource. Write tools have permanent side effects and need stricter conventions than read tools.
+
+#### 9e.i. Tool naming and description
+
+Write tool names must signal intent:
+
+- ✅ `_post_review`, `_update_issue`, `_send_message`, `_create_alarm`
+- ❌ `_save_review` (ambiguous — is this saving locally or posting?), `_handle_pr` (too generic)
+
+Tool descriptions must explicitly state what gets written and where. Bad/good:
+
+- ❌ `"Post a comment to GitHub"`
+- ✅ `"Post a structured review comment to the PR. The comment is visible to all collaborators on the repo and cannot be unsent. Requires GITHUB_TOKEN with 'repo' scope."`
+
+#### 9e.ii. Required: user permission before every write
+
+The skill **MUST** ask the user for explicit permission before calling any write tool. The pattern:
+
+```
+Before calling a write tool, the skill must:
+1. Show the proposed write content to the user (via Claude's chat output)
+2. Ask explicit confirmation: "Should I post this review to GitHub?"
+3. Wait for the user's response
+4. Only proceed if confirmed
+```
+
+This is non-negotiable. Companions that auto-write without asking violate the user's trust and may cause damage that can't be undone. The Claude Code session is what makes this consent flow possible — it's another reason the slash-command handoff is load-bearing (see `docs/followups.md` § Handoff UX).
+
+If the user declines, the skill should still save the artifact (so the work isn't wasted) and note in the artifact that the write was skipped.
+
+#### 9e.iii. About page treatment
+
+The About page (§12c) flags write tools with a different visual treatment so users know what side effects to expect *before* running a companion:
+
+- Read-only companions: subtle "read-only" badge
+- Companions with write tools: prominent "writes to external systems" warning, listing which tools have side effects
+
+#### 9e.iv. Build skill bias toward read-only
+
+When the Build companion scaffolds a new companion from a vague user description, **it leans toward read-only proxy tools by default.**
+
+Example: if the user types *"build me a PR reviewer"*, Build creates a companion that produces a structured review artifact — **not** one that auto-posts to GitHub. Write tools are added only when the user explicitly requests them: *"and have it post the review back to GitHub."*
+
+Rationale:
+
+- Read-only operations are idempotent and safe to iterate on. Companions get re-run frequently during development.
+- Write operations have permanent consequences and require the user's full attention each time.
+- The default should match the lower-risk path. Adding write tools is a deliberate opt-in by the user, not a default expansion of scope.
+
+The Build skill template includes an explicit bias check: when interpreting the user's request, identify whether write actions are explicitly requested. If not, default to read-only.
+
+---
+
+## 10. Error Handling 🎯
+
+Errors are first-class. Every proxy companion encounters them; the host standardizes how they're surfaced and handled.
+
+### 10a. The four error classes
+
+| Class | Prefix | Recovery |
+|---|---|---|
+| `config` | `[config]` | User fixes env var or credential. Skill calls `_fail` immediately. |
+| `input` | `[input]` | User re-runs with corrected form input. Skill calls `_fail` immediately. |
+| `transient` | `[transient]` | Skill retries once with backoff, then `_fail` if still failing. |
+| `recoverable` | `[recoverable]` | Skill logs warning, continues, notes in artifact `errors` array. |
+
+The class is encoded as a prefix on the error message so any client (skill, log viewer, future tooling) can branch on it.
+
+### 10b. Helper functions
+
+The host provides four helpers in `src/shared/types.ts`:
+
+```ts
+export function errorResult(message: string): McpToolResult;
+// Generic — use when none of the classes fit.
+
+export function configErrorResult(envVar: string, hint?: string): McpToolResult;
+// Returns: errorResult(`[config] ${envVar} is not set${hint ? ` — ${hint}` : ""}`)
+
+export function inputErrorResult(message: string): McpToolResult;
+// Returns: errorResult(`[input] ${message}`)
+
+export function transientErrorResult(message: string): McpToolResult;
+// Returns: errorResult(`[transient] ${message}`)
+
+// recoverable errors are logged via _append_log({ level: "warn" }) — not returned as errors
+```
+
+Companion authors use these in proxy tool handlers (see §9d).
+
+### 10c. The skill's standard error handling
+
+The skill template includes a fixed pattern:
+
+```markdown
+## Step 2 — Preflight check 🎯
+
+Before doing any work, verify config:
+
+curl -s http://localhost:3001/api/companions/<name>/preflight
+
+If the response shows missingRequired non-empty, call:
+mcp__claudepanion__<name>_fail({ id, errorMessage: "[config] missing: <list>" })
+and stop.
+
+## Error handling
+
+When a proxy tool returns an error, branch on the prefix:
+
+- [config]      → call <name>_fail({ id, errorMessage: <message> }) and stop
+- [input]       → call <name>_fail({ id, errorMessage: <message> }) and stop
+- [transient]   → call <name>_append_log({ id, message: <message>, level: "warn" })
+                  retry the tool ONCE
+                  if still failing, call <name>_fail
+- [recoverable] → call <name>_append_log({ id, message: <message>, level: "warn" })
+                  continue
+                  add the message to the artifact's errors[] field
+- (no prefix)   → treat as fatal: <name>_fail
+```
+
+This is the same for every companion. The skill template ships with this section pre-filled.
+
+### 10d. The artifact `errors` convention
+
+Every artifact type optionally carries an `errors?: string[]` field for partial-success runs:
+
+```ts
+export interface PrReviewerArtifact {
+  prTitle: string;
+  prUrl: string;
+  reviewPosted: boolean;
+  summary: string;
+  risks: string[];
+  questions: string[];
+  recommendation: "approve" | "request_changes" | "comment";
+  errors?: string[];                   // any [recoverable] issues encountered
+}
+```
+
+This is convention, not enforced by a base type. The skill populates it from log warnings; the Detail page renders it as a "Notes during this run" section.
+
+---
+
+## 11. The Artifact
+
+The artifact is the durable output of a run. Saved via `_save_artifact`, rendered by the Detail page.
+
+### 11a. Artifact type
+
+Defined in `companions/<name>/types.ts` alongside the input type:
+
+```ts
+export interface PrReviewerArtifact {
+  prTitle: string;
+  prUrl: string;
+  reviewPosted: boolean;
+  summary: string;
+  risks: string[];
+  questions: string[];
+  recommendation: "approve" | "request_changes" | "comment";
+  errors?: string[];
+}
+```
+
+Conventions:
+- One artifact type per companion.
+- All fields the Detail page references must be defined in the type.
+- Optional `errors?: string[]` per §10d.
+- Should be JSON-serializable (no functions, no Dates — use ISO strings).
+
+### 11b. Detail rendering
+
+```ts
+// companions/<name>/pages/Detail.tsx
+type ArtifactRenderer = ComponentType<{ entity: Entity }>;
+
+export default function PrReviewerDetail({ entity }: { entity: Entity<PrReviewerInput, PrReviewerArtifact> }) {
+  if (!entity.artifact) return null;
+  // render entity.artifact however makes sense
+}
+```
+
+Registered in `companions/client.ts`. Host's `getArtifactRenderer(name)` resolves the component for a completed entity.
+
+---
+
+## 12. List & Detail Pages
+
+### 12a. The List row
+
+```ts
+// companions/<name>/pages/List.tsx
+type ListRow = ComponentType<{ entity: Entity }>;
+```
+
+Renders one entity's summary row in the companion's list view. Host wraps it with status pill, timestamp, and a link to the Detail page.
+
+### 12b. The Detail page
+
+The host provides the Detail page chrome (header, status pill, log tail, artifact area, Continue button). The companion provides only the artifact renderer (§11b) — the rest is generic.
+
+### 12c. The About page 🎯
+
+Every companion has an auto-generated About page at `/c/<name>` that serves as the user's first exposure before creating an entity. Rendered by the host from the manifest, preflight, and tool definitions — no per-companion code.
+
+**The About page renders:**
+
+- Manifest fields: `displayName`, `icon`, `description`, `version`
+- Preflight status (live): `requiredEnv` and `optionalEnv` with their current set/missing state. Banner if anything is missing.
+- Domain proxy tools: list of tool names + descriptions, pulled directly from `CompanionToolDefinition`
+- Write tools: flagged separately with a "writes to external systems" badge and the specific external system listed
+- Action: "Start a new run" button (or for tool-kind, the existing Try-it panel)
+
+**Visual differentiation:**
+
+- Read-only companions: subtle "read-only" badge in the header
+- Companions with write tools: prominent warning banner near the top, listing each write tool with its description
+
+**Implementation:** single `<CompanionAbout>` component the host renders for any companion. Companion authors don't write About pages.
+
+For tool-kind companions, the About page also includes the Try-it panel (already shipped).
+
+---
+
+## 13. Registration & Discovery
+
+### 13a. File structure
+
+```
+companions/<name>/
+├── manifest.ts            # Manifest export
+├── index.ts               # RegisteredCompanion export (binds manifest + tools)
+├── types.ts               # Input + Artifact types
+├── form.tsx               # Form component
+├── pages/
+│   ├── List.tsx           # List row
+│   └── Detail.tsx         # Artifact renderer
+└── server/
+    └── tools.ts           # CompanionToolDefinition[] export
+```
+
+### 13b. Two-file registration
+
+Every entity companion must be registered in both:
+
+1. **`companions/index.ts`** — server-side registry (read by the host MCP server)
+
+   ```ts
+   import { prReviewer } from "./pr-reviewer/index.js";
+   export const companions: RegisteredCompanion[] = [build, prReviewer /*, …alphabetical*/];
+   ```
+
+2. **`companions/client.ts`** — client-side registry (read by the React app)
+
+   ```ts
+   import PrReviewerDetail from "./pr-reviewer/pages/Detail";
+   import PrReviewerListRow from "./pr-reviewer/pages/List";
+   import PrReviewerForm from "./pr-reviewer/form";
+
+   const artifactRenderers = { "pr-reviewer": PrReviewerDetail as ArtifactRenderer };
+   const listRows = { "pr-reviewer": PrReviewerListRow as ListRow };
+   const forms = { "pr-reviewer": PrReviewerForm as CompanionForm };
+   ```
+
+Missing either file = "No form registered" or "No tools" runtime errors. Both are mandatory.
+
+### 13c. The `RegisteredCompanion` shape
+
+```ts
+export interface RegisteredCompanion {
+  manifest: Manifest;
+  tools: CompanionToolDefinition[];        // domain proxy tools only
+  source?: "local" | "installed";          // local = on-disk; installed = npm package
+}
+```
+
+Generic entity tools are auto-added by the host — companions only declare their domain tools.
+
+### 13d. External dependencies
+
+External libraries (SDKs, API clients) are declared based on whether the companion is local or installed.
+
+**Local companions** (in `companions/<name>/`):
+
+- Add their dependencies to the host's top-level `package.json`
+- Examples: PR reviewer adds `@octokit/rest`, CloudWatch adds `@aws-sdk/client-cloudwatch-logs`, Linear adds `@linear/sdk`
+- Reason: local companions are part of the host's build; they share the host's `node_modules`
+
+**Installed companions** (npm package `claudepanion-<name>`):
+
+- Declare dependencies in their own `package.json`
+- Brought along automatically when the user runs `npm install claudepanion-<name>` (or via `claudepanion plugin install`)
+- Reason: installed companions are independently published and consumed; they own their dependency tree
+
+**Convention:** every companion's README lists its external dependencies and the credentials/config it needs. This makes evaluation easy when contributing back to the host or when a user is deciding whether to install a third-party companion.
+
+---
+
+## 14. Reliability
+
+### 14a. Validator
+
+`src/server/reliability/validator.ts` runs at companion register and on every reload:
+
+- Manifest schema valid (name regex, kind enum, contractVersion match, semver, etc.)
+- Required files present (`form.tsx`, `pages/List.tsx`, `pages/Detail.tsx`, `types.ts`, `server/tools.ts` for entity kind)
+- Tool names prefixed with `<name>_`
+- 🎯 `requiredEnv` declared if the companion's tools reference `process.env.*`
+
+Validator issues are surfaced via `GET /api/reliability/<name>`. Fatal issues block the companion from registering; non-fatal issues become warnings on the About page.
+
+### 14b. Smoke test
+
+`src/server/reliability/smoke.ts` calls every domain tool with empty args and classifies the result:
+- Resolved → ok
+- Rejected with validation-shaped error → ok (the tool correctly rejected bad input)
+- Rejected with `TypeError` / `ReferenceError` / `SyntaxError` → fail (code-level bug)
+
+Smoke runs at register and on every reload. Used to catch typos and broken imports before a user hits them.
+
+### 14c. Watcher
+
+`src/server/reliability/watcher.ts` (chokidar) watches `companions/*/manifest.ts` and re-imports affected companions on change. No server restart needed for iteration. The companion needs `tsc` to have rebuilt to `dist/` — `npm run dev` runs `tsc --watch` in parallel.
+
+---
+
+## 15. Patterns & Conventions
+
+### 15a. Naming
+
+- **Slug** (`name`): `kebab-case`, regex `/^[a-z][a-z0-9-]*$/`. Examples: `pr-reviewer`, `cloudwatch-investigator`.
+- **Camel binding** (used in code imports): `prReviewer`, `cloudwatchInvestigator`.
+- **Pascal type** (used in interface/component names): `PrReviewerInput`, `CloudwatchInvestigatorArtifact`.
+- **Tool prefix**: always `<slug>_`. e.g. `pr_reviewer_get_diff` (note: hyphens in the slug become underscores when used as a tool prefix because tool names can't contain hyphens — actually, double-check with the validator... see TODO).
+
+### 15b. Error message format
+
+Always `[<class>] <message>` for proxy tool errors. Plain message (no prefix) is treated as fatal generic error.
+
+### 15c. Artifact `errors[]`
+
+Always include this field on artifact types when the run does any optional work that could fail recoverably. Skill populates it from log warnings.
+
+### 15d. Status messages
+
+Short, human-readable, present tense. Examples:
+- `"querying CloudWatch"`
+- `"fetching PR diff"`
+- `"posting review to GitHub"`
+- `"writing report"`
+
+Avoid technical noise: not `"step 4 of 7"`, not `"calling pr_reviewer_get_diff"`.
+
+### 15e. Log messages
+
+Same style as status, but past tense — they describe what just happened:
+- `"Fetched PR #142 (47 files, +1240 / -380)"`
+- `"Found 3 risky diffs"`
+- `"Posted review to GitHub"`
+
+Each `_append_log` should mark a meaningful step, not every tool call. The user is reading these to understand what Claude did.
+
+### 15f. The skill is the program
+
+If logic varies between companions, it lives in the skill. The proxy tools are stateless thin wrappers around external APIs; they don't decide policy. The skill decides:
+- Order of operations
+- When to retry
+- What to do with results
+- When to stop
+
+This keeps proxy tools small and testable, and makes skill diffs the readable artifact when behavior changes.
+
+---
+
+## Implementation status
+
+This spec describes the target. Current state vs. spec:
+
+| Section | Status |
+|---|---|
+| 2. Lifecycle | ✅ Shipped |
+| 3. Manifest (existing fields) | ✅ Shipped |
+| 3. Manifest `requiredEnv`/`optionalEnv` | 🎯 Not yet |
+| 4. Configuration & preflight | 🎯 Not yet |
+| 5. Form contract | ✅ Shipped (form mostly), 🎯 preflight banner |
+| 6. Entity | ✅ Shipped |
+| 7. Skill template | ✅ Shipped (existing template), 🎯 preflight + error sections |
+| 7d. Continuation contract | ✅ Endpoint shipped, 🎯 skill template stanza |
+| 8. Generic entity tools | ✅ Shipped (with proper Zod schemas after recent refactor) |
+| 9. `CompanionToolDefinition` | ✅ Shipped |
+| 9e. Write-action safety | 🎯 Not yet (conventions only, no helpers needed) |
+| 10. Error handling helpers | 🎯 Not yet (`configErrorResult`, `inputErrorResult`, `transientErrorResult`) |
+| 10. Skill error pattern | 🎯 Not yet (template additions) |
+| 10. Artifact `errors[]` convention | 🎯 Not yet (convention, no code change needed but docs to write) |
+| 11. Artifact rendering | ✅ Shipped |
+| 12. List & Detail pages | ✅ Shipped |
+| 12c. About page (entity kind) | 🎯 Not yet — auto-generated `<CompanionAbout>` component |
+| 13. Registration | ✅ Shipped |
+| 13d. External dependencies | ✅ Convention documented (top-level for local, own pkg.json for installed) |
+| 14. Validator / smoke / watcher | ✅ Shipped (validator may need `requiredEnv` rule) |
+
+**Foundation work to land before chip examples:**
+
+1. Manifest `requiredEnv` / `optionalEnv` fields
+2. `GET /api/companions/:name/preflight` endpoint
+3. `<PreflightBanner />` form component + form integration
+4. Error helpers in `shared/types.ts`
+5. Skill template — preflight section + error handling section + continuation detection stanza
+6. `<CompanionAbout>` component (read-only / write-warning treatment)
+7. Build skill template — explicit read-only bias when interpreting vague descriptions
+8. Doc note on artifact `errors[]` convention
+
+That's a tight, focused PR before the first chip example lands.

--- a/docs/superpowers/plans/2026-04-25-scaffold-foundation.md
+++ b/docs/superpowers/plans/2026-04-25-scaffold-foundation.md
@@ -1,0 +1,2064 @@
+# Scaffold Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the foundation primitives (config preflight, error helpers, write-tool safety, BaseArtifact, About page) so chip examples can be built on a clean contract.
+
+**Architecture:** Four phases. Phase 1 adds type contracts only — no behavior change. Phase 2 adds the preflight endpoint and form banner. Phase 3 builds the About page (default landing per `/c/<name>`) plus generic artifact rendering. Phase 4 updates skill templates.
+
+**Tech Stack:** TypeScript, React 18, Vite 6, Express, Zod 4, Vitest, MCP SDK. The host runs on one Express process at port 3001 serving REST API, MCP, and the React SPA.
+
+**Spec reference:** `docs/scaffold-spec.md` is the contract this plan satisfies.
+
+---
+
+## File structure
+
+### Files to create
+
+| Path | Responsibility |
+|---|---|
+| `src/client/hooks/usePreflight.ts` | Fetches preflight status for a companion; exposes `{ ok, missingRequired, missingOptional, loading }` |
+| `src/client/components/PreflightBanner.tsx` | Renders blocking/soft banners based on preflight status |
+| `src/client/components/BaseArtifactPanel.tsx` | Generic wrapper rendering `summary` + companion artifact + `errors[]` |
+| `src/client/pages/CompanionAbout.tsx` | About page for any companion (manifest + preflight + tools) |
+| `src/client/pages/EntityList.tsx` | NOTE: already exists. Will be relocated route-wise to `/c/:companion/runs` |
+| `tests/client/PreflightBanner.test.tsx` | Banner rendering tests |
+| `tests/client/BaseArtifactPanel.test.tsx` | Panel rendering tests |
+| `tests/client/CompanionAbout.test.tsx` | About page tests |
+| `tests/client/usePreflight.test.tsx` | Hook tests |
+
+### Files to modify
+
+| Path | Change |
+|---|---|
+| `src/shared/types.ts` | Add `BaseArtifact`, manifest fields, `sideEffect`, error helpers |
+| `src/server/api-routes.ts` | Add `GET /api/companions/:name/preflight`; extend `/api/tools/:companion` with `sideEffect` |
+| `src/server/reliability/validator.ts` | Accept `requiredEnv` / `optionalEnv` if present (no enforcement) |
+| `companions/build/types.ts` | `BuildArtifact extends BaseArtifact` |
+| `src/client/App.tsx` | Add routes: `/c/:companion` → About (was List), `/c/:companion/runs` → List |
+| `src/client/pages/CompanionRoute.tsx` | Route to About by default (was List for entity-kind) |
+| `src/client/pages/NewEntity.tsx` | Embed `<PreflightBanner>` above the form |
+| `src/client/pages/EntityDetail.tsx` | Wrap completed body's artifact in `<BaseArtifactPanel>` |
+| `src/client/components/Sidebar.tsx` | Update links to `/c/:name` (was `/c/:name`) — verify link target stays correct |
+| `src/client/components/Breadcrumb.tsx` | Verify breadcrumb to companion home points to About |
+| `companions/build/templates/skill.md` | Add continuation, preflight, error handling sections |
+| `skills/build-companion/SKILL.md` | Add explicit read-only bias when interpreting requests |
+| `companions/build/templates/entity/server/tools.ts` | Comment example using new error helpers |
+| `docs/scaffold-spec.md` | Update §11 to mention `BaseArtifact`; update implementation status table |
+| `tests/server/api-routes.test.ts` | Tests for preflight endpoint and `sideEffect` field |
+| `tests/server/companion-registry.test.ts` | Manifest with `requiredEnv` accepted |
+| `tests/server/tool-meta.test.ts` | Tests for `configErrorResult`, `inputErrorResult`, `transientErrorResult` |
+| `tests/server/reliability/validator.test.ts` | Validator accepts manifest with `requiredEnv` |
+
+---
+
+## Phase 1 — Type Contracts
+
+### Task 1: Add `BaseArtifact`, `sideEffect`, and error helpers to `shared/types.ts`
+
+**Files:**
+- Modify: `src/shared/types.ts`
+- Test: `tests/server/tool-meta.test.ts`
+
+- [ ] **Step 1: Write failing tests for the three error helpers**
+
+Append to `tests/server/tool-meta.test.ts` after the existing describe blocks:
+
+```ts
+import { configErrorResult, inputErrorResult, transientErrorResult } from "../../src/shared/types";
+
+describe("error class helpers", () => {
+  it("configErrorResult prefixes [config] and includes envVar", () => {
+    const r = configErrorResult("GITHUB_TOKEN");
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toBe("[config] GITHUB_TOKEN is not set");
+  });
+
+  it("configErrorResult includes hint when provided", () => {
+    const r = configErrorResult("GITHUB_TOKEN", "create a token with repo scope");
+    expect(r.content[0].text).toBe("[config] GITHUB_TOKEN is not set — create a token with repo scope");
+  });
+
+  it("inputErrorResult prefixes [input]", () => {
+    const r = inputErrorResult("PR not found");
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toBe("[input] PR not found");
+  });
+
+  it("transientErrorResult prefixes [transient]", () => {
+    const r = transientErrorResult("rate limited");
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toBe("[transient] rate limited");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/server/tool-meta.test.ts`
+Expected: 4 new tests fail with "configErrorResult is not a function" or similar import error.
+
+- [ ] **Step 3: Add `BaseArtifact`, `sideEffect`, and helpers to `src/shared/types.ts`**
+
+Append to `src/shared/types.ts` (after `errorResult`):
+
+```ts
+export function configErrorResult(envVar: string, hint?: string): McpToolResult {
+  return errorResult(`[config] ${envVar} is not set${hint ? ` — ${hint}` : ""}`);
+}
+
+export function inputErrorResult(message: string): McpToolResult {
+  return errorResult(`[input] ${message}`);
+}
+
+export function transientErrorResult(message: string): McpToolResult {
+  return errorResult(`[transient] ${message}`);
+}
+```
+
+Also add the `BaseArtifact` interface near the top (after `Entity`):
+
+```ts
+/**
+ * Common fields every artifact may carry. Companions should extend this
+ * interface for their specific Artifact type.
+ */
+export interface BaseArtifact {
+  /** Short one-liner describing the run's outcome. Shown in the List row and Detail header. */
+  summary?: string;
+  /** Recoverable issues encountered during the run. Rendered as a "Notes during this run" section by the host. */
+  errors?: string[];
+}
+```
+
+Modify `CompanionToolDefinition` to add `sideEffect`:
+
+```ts
+export interface CompanionToolDefinition<
+  TParams extends Record<string, unknown> = Record<string, unknown>,
+> {
+  name: string;
+  description: string;
+  schema: z.ZodRawShape;
+  /** Defaults to "read". Set to "write" for tools that change state in external systems —
+   *  triggers permission-prompt flow in the skill and a warning badge on the About page. */
+  sideEffect?: "read" | "write";
+  handler: (params: TParams) => Promise<McpToolResult>;
+}
+```
+
+Modify `Manifest` to add config fields:
+
+```ts
+export interface Manifest {
+  name: string;
+  kind: CompanionKind;
+  displayName: string;
+  icon: string;
+  description: string;
+  contractVersion: string;
+  version: string;
+  /** Env vars the companion requires. Preflight surfaces missing values; form blocks submission. */
+  requiredEnv?: string[];
+  /** Env vars that enable extra features but aren't required. Preflight surfaces as soft warning. */
+  optionalEnv?: string[];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/server/tool-meta.test.ts`
+Expected: all tests pass (existing + 4 new).
+
+- [ ] **Step 5: Run typecheck to verify no breakage**
+
+Run: `npm run check`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/types.ts tests/server/tool-meta.test.ts
+git commit -m "$(cat <<'EOF'
+feat(types): add BaseArtifact, sideEffect, manifest config fields, error helpers
+
+- BaseArtifact interface: summary?, errors? — companions extend it
+- CompanionToolDefinition.sideEffect: "read" | "write"
+- Manifest.requiredEnv / optionalEnv for declared config dependencies
+- configErrorResult / inputErrorResult / transientErrorResult helpers
+EOF
+)"
+```
+
+### Task 2: Update `BuildArtifact` to extend `BaseArtifact`
+
+**Files:**
+- Modify: `companions/build/types.ts`
+
+- [ ] **Step 1: Update the interface**
+
+Replace the file contents:
+
+```ts
+import type { BaseArtifact } from "../../src/shared/types.js";
+
+export type BuildInput =
+  | {
+      mode: "new-companion";
+      name: string;
+      kind: "entity" | "tool";
+      description: string;
+      /** Slug of the BuildExample that prefilled this submission, if any. Drives skillTemplate lookup during scaffolding. */
+      example?: string;
+    }
+  | {
+      mode: "iterate-companion";
+      target: string;
+      description: string;
+    };
+
+export interface BuildArtifact extends BaseArtifact {
+  filesCreated: string[];
+  filesModified: string[];
+  /** Required for Build runs (overrides BaseArtifact's optional summary). */
+  summary: string;
+  validatorPassed: boolean;
+  smokeTestPassed: boolean;
+}
+```
+
+- [ ] **Step 2: Verify typecheck still passes**
+
+Run: `npm run check`
+Expected: no errors. The `summary: string` (required) overrides `summary?: string` (optional) — TypeScript allows this narrowing.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `npm test -- --run`
+Expected: all 102+ tests pass (4 new from Task 1).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add companions/build/types.ts
+git commit -m "feat(build): BuildArtifact extends BaseArtifact"
+```
+
+### Task 3: Update validator to accept new manifest fields
+
+**Files:**
+- Modify: `src/server/reliability/validator.ts` (no functional change — fields are accepted as `any` extras since validator doesn't reject unknown fields, but add explicit type signal)
+- Test: `tests/server/reliability/validator.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/server/reliability/validator.test.ts`:
+
+```ts
+it("accepts manifest with requiredEnv and optionalEnv", () => {
+  const r = validateCompanion({
+    manifest: { ...baseManifest, requiredEnv: ["GITHUB_TOKEN"], optionalEnv: ["SLACK_TOKEN"] },
+    module: null,
+    companionDir: null,
+  });
+  expect(r.ok).toBe(true);
+  expect(r.issues.filter((i) => i.fatal)).toEqual([]);
+});
+
+it("accepts manifest with requiredEnv that is empty array", () => {
+  const r = validateCompanion({
+    manifest: { ...baseManifest, requiredEnv: [] },
+    module: null,
+    companionDir: null,
+  });
+  expect(r.ok).toBe(true);
+});
+
+it("flags non-array requiredEnv as non-fatal", () => {
+  const r = validateCompanion({
+    manifest: { ...baseManifest, requiredEnv: "GITHUB_TOKEN" as any },
+    module: null,
+    companionDir: null,
+  });
+  expect(r.issues.some((i) => i.code === "manifest.requiredEnv.invalid")).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/server/reliability/validator.test.ts`
+Expected: third test fails — no `manifest.requiredEnv.invalid` issue produced.
+
+- [ ] **Step 3: Add validation in validator.ts**
+
+Add this block in `validateCompanion` after the existing `displayName/icon/description` loop, before the tool name check:
+
+```ts
+for (const field of ["requiredEnv", "optionalEnv"] as const) {
+  const v = (m as any)[field];
+  if (v !== undefined && (!Array.isArray(v) || v.some((x) => typeof x !== "string"))) {
+    issues.push({
+      code: `manifest.${field}.invalid`,
+      message: `${field} must be a string[] when present`,
+      fatal: false,
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/server/reliability/validator.test.ts`
+Expected: all pass (existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/reliability/validator.ts tests/server/reliability/validator.test.ts
+git commit -m "feat(validator): accept and shape-check requiredEnv/optionalEnv"
+```
+
+---
+
+## Phase 2 — Preflight System
+
+### Task 4: Add `GET /api/companions/:name/preflight` endpoint
+
+**Files:**
+- Modify: `src/server/api-routes.ts`
+- Test: `tests/server/api-routes.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/server/api-routes.test.ts` inside the existing `describe("api routes", ...)` block:
+
+```ts
+it("GET /api/companions/:name/preflight returns ok:true for companion with no env declared", async () => {
+  const res = await request(app).get("/api/companions/x/preflight");
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({ ok: true, missingRequired: [], missingOptional: [] });
+});
+
+it("GET /api/companions/:name/preflight 404s for unknown companion", async () => {
+  const res = await request(app).get("/api/companions/nope/preflight");
+  expect(res.status).toBe(404);
+});
+```
+
+For requiredEnv testing, we need a companion declared with env vars. Add a new test block at the end of the file:
+
+```ts
+describe("preflight with required env", () => {
+  let envBackup: string | undefined;
+
+  beforeEach(() => {
+    envBackup = process.env.X_TOKEN;
+    delete process.env.X_TOKEN;
+  });
+
+  afterEach(() => {
+    if (envBackup !== undefined) process.env.X_TOKEN = envBackup;
+    else delete process.env.X_TOKEN;
+  });
+
+  function setupAppWithEnv(reqEnv: string[], optEnv: string[] = []) {
+    const tmp2 = mkdtempSync(join(tmpdir(), "claudepanion-pf-"));
+    const store = createEntityStore(tmp2);
+    const m: Manifest = { ...manifest("env-test"), requiredEnv: reqEnv, optionalEnv: optEnv };
+    const registry = createRegistry([{ manifest: m, tools: [] }]);
+    const app2 = express();
+    app2.use(express.json());
+    mountApiRoutes(app2, { store, registry });
+    return app2;
+  }
+
+  it("preflight reports missingRequired when env not set", async () => {
+    const a = setupAppWithEnv(["X_TOKEN"]);
+    const res = await request(a).get("/api/companions/env-test/preflight");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.missingRequired).toEqual(["X_TOKEN"]);
+  });
+
+  it("preflight returns ok:true when required env is set", async () => {
+    process.env.X_TOKEN = "value";
+    const a = setupAppWithEnv(["X_TOKEN"]);
+    const res = await request(a).get("/api/companions/env-test/preflight");
+    expect(res.body.ok).toBe(true);
+    expect(res.body.missingRequired).toEqual([]);
+  });
+
+  it("preflight reports missingOptional but ok:true when only optional is missing", async () => {
+    const a = setupAppWithEnv([], ["OPT_TOKEN"]);
+    const res = await request(a).get("/api/companions/env-test/preflight");
+    expect(res.body.ok).toBe(true);
+    expect(res.body.missingOptional).toEqual(["OPT_TOKEN"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/server/api-routes.test.ts`
+Expected: 5 new tests fail with 404 (route doesn't exist).
+
+- [ ] **Step 3: Implement the endpoint**
+
+In `src/server/api-routes.ts`, add this route inside `mountApiRoutes` near the other `app.get("/api/companions...")` handlers:
+
+```ts
+app.get("/api/companions/:name/preflight", (req: Request, res: Response) => {
+  const name = String(req.params.name);
+  const c = registry.get(name);
+  if (!c) return res.status(404).json({ error: `unknown companion: ${name}` });
+  const requiredEnv = c.manifest.requiredEnv ?? [];
+  const optionalEnv = c.manifest.optionalEnv ?? [];
+  const missingRequired = requiredEnv.filter((v) => !process.env[v]);
+  const missingOptional = optionalEnv.filter((v) => !process.env[v]);
+  res.json({ ok: missingRequired.length === 0, missingRequired, missingOptional });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/server/api-routes.test.ts`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/api-routes.ts tests/server/api-routes.test.ts
+git commit -m "feat(api): preflight endpoint reports config readiness from requiredEnv/optionalEnv"
+```
+
+### Task 5: Build the `usePreflight` hook
+
+**Files:**
+- Create: `src/client/hooks/usePreflight.ts`
+- Create: `tests/client/usePreflight.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/client/usePreflight.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { usePreflight } from "../../src/client/hooks/usePreflight";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url === "/api/companions/x/preflight") {
+      return new Response(JSON.stringify({ ok: false, missingRequired: ["TOKEN"], missingOptional: [] }), { status: 200 });
+    }
+    if (url === "/api/companions/y/preflight") {
+      return new Response(JSON.stringify({ ok: true, missingRequired: [], missingOptional: [] }), { status: 200 });
+    }
+    if (url === "/api/companions/missing/preflight") {
+      return new Response(JSON.stringify({ error: "unknown" }), { status: 404 });
+    }
+    throw new Error(`unexpected url: ${url}`);
+  }));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("usePreflight", () => {
+  it("returns missingRequired when env is not set", async () => {
+    const { result } = renderHook(() => usePreflight("x"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.ok).toBe(false);
+    expect(result.current.missingRequired).toEqual(["TOKEN"]);
+  });
+
+  it("returns ok:true when no missing env", async () => {
+    const { result } = renderHook(() => usePreflight("y"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.ok).toBe(true);
+  });
+
+  it("treats 404 as ok:true (companion has no preflight requirement)", async () => {
+    const { result } = renderHook(() => usePreflight("missing"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.ok).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `npx vitest run tests/client/usePreflight.test.tsx`
+Expected: import error — file doesn't exist.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/client/hooks/usePreflight.ts`:
+
+```ts
+import { useEffect, useState } from "react";
+
+export interface PreflightStatus {
+  ok: boolean;
+  missingRequired: string[];
+  missingOptional: string[];
+  loading: boolean;
+}
+
+const INITIAL: PreflightStatus = { ok: true, missingRequired: [], missingOptional: [], loading: true };
+
+export function usePreflight(companion: string | undefined): PreflightStatus {
+  const [status, setStatus] = useState<PreflightStatus>(INITIAL);
+
+  useEffect(() => {
+    if (!companion) return;
+    let cancelled = false;
+    setStatus(INITIAL);
+    void (async () => {
+      try {
+        const r = await fetch(`/api/companions/${encodeURIComponent(companion)}/preflight`);
+        if (cancelled) return;
+        if (r.status === 404) {
+          // Treat as no preflight requirement — backwards-compatible.
+          setStatus({ ok: true, missingRequired: [], missingOptional: [], loading: false });
+          return;
+        }
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const data = await r.json();
+        setStatus({ ...data, loading: false });
+      } catch {
+        if (!cancelled) setStatus({ ok: true, missingRequired: [], missingOptional: [], loading: false });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [companion]);
+
+  return status;
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `npx vitest run tests/client/usePreflight.test.tsx`
+Expected: all 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/hooks/usePreflight.ts tests/client/usePreflight.test.tsx
+git commit -m "feat(client): usePreflight hook fetches companion preflight status"
+```
+
+### Task 6: Build `PreflightBanner` component
+
+**Files:**
+- Create: `src/client/components/PreflightBanner.tsx`
+- Create: `tests/client/PreflightBanner.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/client/PreflightBanner.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import PreflightBanner from "../../src/client/components/PreflightBanner";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url === "/api/companions/blocked/preflight") {
+      return new Response(JSON.stringify({ ok: false, missingRequired: ["GITHUB_TOKEN"], missingOptional: [] }), { status: 200 });
+    }
+    if (url === "/api/companions/warn/preflight") {
+      return new Response(JSON.stringify({ ok: true, missingRequired: [], missingOptional: ["SLACK_TOKEN"] }), { status: 200 });
+    }
+    if (url === "/api/companions/ok/preflight") {
+      return new Response(JSON.stringify({ ok: true, missingRequired: [], missingOptional: [] }), { status: 200 });
+    }
+    throw new Error(`unexpected url: ${url}`);
+  }));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("PreflightBanner", () => {
+  it("renders blocking banner when missingRequired non-empty", async () => {
+    render(<PreflightBanner companion="blocked" />);
+    await waitFor(() => expect(screen.getByText(/GITHUB_TOKEN/)).toBeInTheDocument());
+    expect(screen.getByRole("alert")).toHaveTextContent(/required/i);
+  });
+
+  it("renders soft banner when only missingOptional", async () => {
+    render(<PreflightBanner companion="warn" />);
+    await waitFor(() => expect(screen.getByText(/SLACK_TOKEN/)).toBeInTheDocument());
+    expect(screen.getByRole("status")).toHaveTextContent(/optional/i);
+  });
+
+  it("renders nothing when all env is set", async () => {
+    const { container } = render(<PreflightBanner companion="ok" />);
+    await waitFor(() => expect(container.textContent).not.toContain("loading"));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("calls onStatus with blocked=true when required env missing", async () => {
+    const onStatus = vi.fn();
+    render(<PreflightBanner companion="blocked" onStatus={onStatus} />);
+    await waitFor(() => expect(onStatus).toHaveBeenCalledWith(expect.objectContaining({ blocked: true })));
+  });
+
+  it("calls onStatus with blocked=false when ok", async () => {
+    const onStatus = vi.fn();
+    render(<PreflightBanner companion="ok" onStatus={onStatus} />);
+    await waitFor(() => expect(onStatus).toHaveBeenCalledWith(expect.objectContaining({ blocked: false })));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npx vitest run tests/client/PreflightBanner.test.tsx`
+Expected: import error.
+
+- [ ] **Step 3: Implement the component**
+
+Create `src/client/components/PreflightBanner.tsx`:
+
+```tsx
+import { useEffect } from "react";
+import { usePreflight } from "../hooks/usePreflight";
+
+export interface PreflightBannerProps {
+  companion: string;
+  /** Called whenever the preflight status changes. Useful for the parent form to disable submit. */
+  onStatus?: (s: { blocked: boolean; missingRequired: string[]; missingOptional: string[] }) => void;
+}
+
+export default function PreflightBanner({ companion, onStatus }: PreflightBannerProps) {
+  const status = usePreflight(companion);
+
+  useEffect(() => {
+    if (status.loading) return;
+    onStatus?.({
+      blocked: !status.ok,
+      missingRequired: status.missingRequired,
+      missingOptional: status.missingOptional,
+    });
+  }, [status.loading, status.ok, status.missingRequired, status.missingOptional, onStatus]);
+
+  if (status.loading) return null;
+  if (status.ok && status.missingOptional.length === 0) return null;
+
+  if (!status.ok) {
+    return (
+      <div role="alert" className="preflight-banner preflight-banner-blocking">
+        <strong>⚠️ Configuration required.</strong>{" "}
+        This companion needs the following environment {status.missingRequired.length === 1 ? "variable" : "variables"} to run:
+        <ul style={{ margin: "8px 0 0 20px" }}>
+          {status.missingRequired.map((v) => (<li key={v}><code>{v}</code></li>))}
+        </ul>
+        <div style={{ marginTop: 8, fontSize: 12, color: "var(--muted)" }}>
+          Set them in your environment, then reload this page.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div role="status" className="preflight-banner preflight-banner-soft">
+      <strong>Optional config not set.</strong>{" "}
+      Some features may be limited:
+      <ul style={{ margin: "8px 0 0 20px" }}>
+        {status.missingOptional.map((v) => (<li key={v}><code>{v}</code></li>))}
+      </ul>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Add CSS**
+
+Append to `src/client/styles.css` (or wherever the global styles live — check `src/client/main.tsx` import to confirm path):
+
+```css
+.preflight-banner {
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+.preflight-banner-blocking {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+}
+.preflight-banner-soft {
+  background: #fefce8;
+  border: 1px solid #fde68a;
+  color: #854d0e;
+}
+.preflight-banner code {
+  background: rgba(0, 0, 0, 0.05);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+```
+
+If `src/client/styles.css` doesn't exist, add the styles inline via the component's existing `style` props.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `npx vitest run tests/client/PreflightBanner.test.tsx`
+Expected: all 5 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/client/components/PreflightBanner.tsx tests/client/PreflightBanner.test.tsx src/client/styles.css
+git commit -m "feat(client): PreflightBanner renders blocking and soft banners from preflight status"
+```
+
+### Task 7: Wire `PreflightBanner` into `NewEntity`
+
+**Files:**
+- Modify: `src/client/pages/NewEntity.tsx`
+- Modify: `tests/client/NewEntity.test.tsx`
+
+- [ ] **Step 1: Update the failing test**
+
+Add a new test block to `tests/client/NewEntity.test.tsx` after the existing test:
+
+```tsx
+it("disables submit when preflight reports blocked status", async () => {
+  // Override fetch to return a blocked preflight for build
+  vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === "/api/companions") {
+      return new Response(JSON.stringify([
+        { name: "build", kind: "entity", displayName: "Build", icon: "🔨", description: "", contractVersion: "1", version: "0.1.0", requiredEnv: ["BLOCKED_TOKEN"] },
+      ]), { status: 200 });
+    }
+    if (url === "/api/companions/build/preflight") {
+      return new Response(JSON.stringify({ ok: false, missingRequired: ["BLOCKED_TOKEN"], missingOptional: [] }), { status: 200 });
+    }
+    if (url === "/api/entities" && init?.method === "POST") {
+      return new Response(JSON.stringify({ id: "build-zzz999", companion: "build", status: "pending", input: {}, logs: [], createdAt: "", updatedAt: "", statusMessage: null, artifact: null, errorMessage: null, errorStack: null }), { status: 201 });
+    }
+    throw new Error(`unexpected ${url}`);
+  }));
+
+  render(
+    <MemoryRouter initialEntries={["/c/build/new"]}>
+      <Routes>
+        <Route path="/c/:companion/new" element={<NewEntity />} />
+      </Routes>
+    </MemoryRouter>
+  );
+  await waitFor(() => expect(screen.getByText(/BLOCKED_TOKEN/)).toBeInTheDocument());
+  // Submit button should be disabled
+  const button = screen.getByRole("button", { name: /scaffold companion/i });
+  expect(button).toBeDisabled();
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `npx vitest run tests/client/NewEntity.test.tsx`
+Expected: new test fails — banner not present, button not disabled.
+
+- [ ] **Step 3: Update NewEntity to render the banner and respect blocked state**
+
+Replace `src/client/pages/NewEntity.tsx`:
+
+```tsx
+import { useParams, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import type { Manifest } from "@shared/types";
+import { createEntity, fetchCompanions } from "../api";
+import { getForm } from "../../../companions/client";
+import Breadcrumb from "../components/Breadcrumb";
+import PreflightBanner from "../components/PreflightBanner";
+
+export default function NewEntity() {
+  const { companion = "" } = useParams();
+  const navigate = useNavigate();
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [blocked, setBlocked] = useState(false);
+
+  useEffect(() => {
+    void fetchCompanions().then((all) => setManifest(all.find((m) => m.name === companion) ?? null));
+  }, [companion]);
+
+  if (!manifest) return <div style={{ color: "var(--muted)" }}>Loading…</div>;
+
+  const Form = getForm(companion);
+  if (!Form) return <div>No form registered for {companion}.</div>;
+
+  return (
+    <>
+      <Breadcrumb manifest={manifest} trailing="New" />
+      <div className="page-title"><h1>{companion === "build" ? "New companion" : "New entry"}</h1></div>
+      <PreflightBanner companion={companion} onStatus={(s) => setBlocked(s.blocked)} />
+      <fieldset disabled={blocked} style={{ border: "none", padding: 0, margin: 0 }}>
+        <Form onSubmit={async (input) => {
+          if (blocked) return;
+          const e = await createEntity(companion, input);
+          navigate(`/c/${companion}/${e.id}`);
+        }} />
+      </fieldset>
+    </>
+  );
+}
+```
+
+The `<fieldset disabled>` pattern disables all form controls inside, including the submit button.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `npm test -- --run`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/pages/NewEntity.tsx tests/client/NewEntity.test.tsx
+git commit -m "feat(client): NewEntity wraps form in PreflightBanner; blocks submission when config missing"
+```
+
+---
+
+## Phase 3 — About Page, Routing, Base Artifact
+
+### Task 8: Add `sideEffect` to `/api/tools/:companion` response
+
+**Files:**
+- Modify: `src/server/api-routes.ts`
+- Modify: `tests/server/api-routes.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/server/api-routes.test.ts` after the existing tests, in a new describe block:
+
+```ts
+import { z } from "zod";
+import { successResult } from "../../src/shared/types";
+import type { CompanionToolDefinition } from "../../src/shared/types";
+
+describe("tools endpoint sideEffect", () => {
+  it("returns sideEffect on each tool descriptor", async () => {
+    const tmp2 = mkdtempSync(join(tmpdir(), "claudepanion-tools-"));
+    const store = createEntityStore(tmp2);
+    const toolReadOnly: CompanionToolDefinition = {
+      name: "tk_read",
+      description: "read",
+      schema: {},
+      sideEffect: "read",
+      async handler() { return successResult({}); },
+    };
+    const toolWrite: CompanionToolDefinition = {
+      name: "tk_write",
+      description: "write",
+      schema: {},
+      sideEffect: "write",
+      async handler() { return successResult({}); },
+    };
+    const m: Manifest = { ...manifest("tk"), kind: "tool" };
+    const registry = createRegistry([{ manifest: m, tools: [toolReadOnly, toolWrite] }]);
+    const app2 = express();
+    app2.use(express.json());
+    mountApiRoutes(app2, { store, registry });
+
+    const res = await request(app2).get("/api/tools/tk");
+    expect(res.status).toBe(200);
+    const tools = res.body.tools as Array<{ name: string; sideEffect?: string }>;
+    expect(tools.find((t) => t.name === "tk_read")?.sideEffect).toBe("read");
+    expect(tools.find((t) => t.name === "tk_write")?.sideEffect).toBe("write");
+  });
+
+  it("defaults sideEffect to 'read' when not specified", async () => {
+    const tmp2 = mkdtempSync(join(tmpdir(), "claudepanion-tools-"));
+    const store = createEntityStore(tmp2);
+    const toolNoFlag: CompanionToolDefinition = {
+      name: "tk_default",
+      description: "no flag",
+      schema: {},
+      async handler() { return successResult({}); },
+    };
+    const m: Manifest = { ...manifest("tk"), kind: "tool" };
+    const registry = createRegistry([{ manifest: m, tools: [toolNoFlag] }]);
+    const app2 = express();
+    app2.use(express.json());
+    mountApiRoutes(app2, { store, registry });
+    const res = await request(app2).get("/api/tools/tk");
+    expect(res.body.tools[0].sideEffect).toBe("read");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npx vitest run tests/server/api-routes.test.ts`
+Expected: 2 new tests fail — `sideEffect` undefined.
+
+- [ ] **Step 3: Update the descriptor in api-routes.ts**
+
+In `src/server/api-routes.ts`, update the descriptors mapping inside the `/api/tools/:companion` handler:
+
+```ts
+const descriptors = c.tools.map((def) => ({
+  name: def.name,
+  description: def.description,
+  params: Object.entries(def.schema).map(([key, schema]) => ({
+    name: key,
+    required: !(schema as any).isOptional?.(),
+    description: (schema as any)._def?.description ?? "",
+  })),
+  signature: signatureFromDef(def),
+  sideEffect: def.sideEffect ?? "read",
+}));
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/server/api-routes.test.ts`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/api-routes.ts tests/server/api-routes.test.ts
+git commit -m "feat(api): /api/tools response carries sideEffect (default 'read')"
+```
+
+### Task 9: Build `BaseArtifactPanel` component
+
+**Files:**
+- Create: `src/client/components/BaseArtifactPanel.tsx`
+- Create: `tests/client/BaseArtifactPanel.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/client/BaseArtifactPanel.test.tsx`:
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import BaseArtifactPanel from "../../src/client/components/BaseArtifactPanel";
+
+const baseEntity = {
+  id: "x-123",
+  companion: "x",
+  status: "completed" as const,
+  statusMessage: null,
+  createdAt: "2026-04-25T00:00:00Z",
+  updatedAt: "2026-04-25T00:00:01Z",
+  input: {},
+  errorMessage: null,
+  errorStack: null,
+  logs: [],
+};
+
+describe("BaseArtifactPanel", () => {
+  it("renders summary banner when artifact has summary", () => {
+    render(
+      <BaseArtifactPanel entity={{ ...baseEntity, artifact: { summary: "All good" } }}>
+        <div>custom-content</div>
+      </BaseArtifactPanel>
+    );
+    expect(screen.getByText("All good")).toBeInTheDocument();
+    expect(screen.getByText("custom-content")).toBeInTheDocument();
+  });
+
+  it("renders errors section when artifact has errors", () => {
+    render(
+      <BaseArtifactPanel entity={{ ...baseEntity, artifact: { errors: ["one failed", "two failed"] } }}>
+        <div>custom-content</div>
+      </BaseArtifactPanel>
+    );
+    expect(screen.getByText("Notes during this run")).toBeInTheDocument();
+    expect(screen.getByText("one failed")).toBeInTheDocument();
+    expect(screen.getByText("two failed")).toBeInTheDocument();
+  });
+
+  it("renders only children when artifact has no summary or errors", () => {
+    render(
+      <BaseArtifactPanel entity={{ ...baseEntity, artifact: { somethingElse: 1 } }}>
+        <div>custom-content</div>
+      </BaseArtifactPanel>
+    );
+    expect(screen.queryByText("Notes during this run")).not.toBeInTheDocument();
+    expect(screen.getByText("custom-content")).toBeInTheDocument();
+  });
+
+  it("renders only children when artifact is null", () => {
+    render(
+      <BaseArtifactPanel entity={{ ...baseEntity, artifact: null }}>
+        <div>custom-content</div>
+      </BaseArtifactPanel>
+    );
+    expect(screen.getByText("custom-content")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npx vitest run tests/client/BaseArtifactPanel.test.tsx`
+Expected: import error.
+
+- [ ] **Step 3: Implement the component**
+
+Create `src/client/components/BaseArtifactPanel.tsx`:
+
+```tsx
+import type { ReactNode } from "react";
+import type { Entity } from "@shared/types";
+
+export interface BaseArtifactPanelProps {
+  entity: Entity;
+  children: ReactNode;
+}
+
+interface PartialBase {
+  summary?: unknown;
+  errors?: unknown;
+}
+
+export default function BaseArtifactPanel({ entity, children }: BaseArtifactPanelProps) {
+  const a = (entity.artifact ?? {}) as PartialBase;
+  const summary = typeof a.summary === "string" && a.summary.trim() ? a.summary : null;
+  const errors = Array.isArray(a.errors) ? a.errors.filter((e): e is string => typeof e === "string") : [];
+
+  return (
+    <>
+      {summary && (
+        <div className="artifact-summary-banner">
+          {summary}
+        </div>
+      )}
+      {children}
+      {errors.length > 0 && (
+        <div className="artifact-errors">
+          <div className="artifact-errors-header">Notes during this run</div>
+          <ul className="artifact-errors-list">
+            {errors.map((e, i) => (<li key={i}>{e}</li>))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+Append CSS to `src/client/styles.css`:
+
+```css
+.artifact-summary-banner {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #14532d;
+  padding: 10px 14px;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  font-size: 14px;
+}
+.artifact-errors {
+  background: #fefce8;
+  border: 1px solid #fde68a;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-top: 12px;
+}
+.artifact-errors-header {
+  font-weight: 600;
+  font-size: 13px;
+  color: #854d0e;
+  margin-bottom: 6px;
+}
+.artifact-errors-list {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 13px;
+  color: #713f12;
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/client/BaseArtifactPanel.test.tsx`
+Expected: all 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/components/BaseArtifactPanel.tsx tests/client/BaseArtifactPanel.test.tsx src/client/styles.css
+git commit -m "feat(client): BaseArtifactPanel renders summary banner and errors[] section"
+```
+
+### Task 10: Wire `BaseArtifactPanel` into `EntityDetail`
+
+**Files:**
+- Modify: `src/client/pages/EntityDetail.tsx`
+- Modify: `tests/client/EntityDetail.test.tsx`
+
+- [ ] **Step 1: Add a test for the panel rendering**
+
+Add to `tests/client/EntityDetail.test.tsx` (alongside existing tests):
+
+```tsx
+it("renders summary banner from artifact", async () => {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url === "/api/companions") return new Response(JSON.stringify([
+      { name: "build", kind: "entity", displayName: "Build", icon: "🔨", description: "", contractVersion: "1", version: "0.1.0" },
+    ]), { status: 200 });
+    if (url.startsWith("/api/entities/build-abc")) return new Response(JSON.stringify({
+      id: "build-abc", companion: "build", status: "completed",
+      statusMessage: null, createdAt: "2026-04-25T00:00:00Z", updatedAt: "2026-04-25T00:00:01Z",
+      input: { mode: "new-companion", name: "x", kind: "entity", description: "" },
+      artifact: { summary: "Scaffolded x.", errors: ["minor warning"], filesCreated: [], filesModified: [], validatorPassed: true, smokeTestPassed: true },
+      errorMessage: null, errorStack: null, logs: [],
+    }), { status: 200 });
+    throw new Error("unexpected");
+  }));
+
+  render(
+    <MemoryRouter initialEntries={["/c/build/build-abc"]}>
+      <Routes>
+        <Route path="/c/:companion/:id" element={<EntityDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+  await waitFor(() => expect(screen.getByText("Scaffolded x.")).toBeInTheDocument());
+  expect(screen.getByText("Notes during this run")).toBeInTheDocument();
+  expect(screen.getByText("minor warning")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `npx vitest run tests/client/EntityDetail.test.tsx`
+Expected: new test fails (no summary rendered yet).
+
+- [ ] **Step 3: Wrap completed body's renderer in BaseArtifactPanel**
+
+In `src/client/pages/EntityDetail.tsx`, modify the `CompletedBody` function:
+
+```tsx
+import BaseArtifactPanel from "../components/BaseArtifactPanel";
+
+// ... inside CompletedBody, change the artifact-hero-body section:
+function CompletedBody({ entity, onContinue }: { entity: Entity; onContinue: (text: string) => void }) {
+  const Renderer = getArtifactRenderer(entity.companion);
+  return (
+    <>
+      <div className="artifact-hero">
+        <div className="artifact-hero-header">
+          <div className="artifact-hero-label">Artifact</div>
+          <div className="artifact-hero-title">Completed</div>
+        </div>
+        <div className="artifact-hero-body">
+          <BaseArtifactPanel entity={entity}>
+            {Renderer ? <Renderer entity={entity} /> : <pre>{JSON.stringify(entity.artifact, null, 2)}</pre>}
+          </BaseArtifactPanel>
+        </div>
+      </div>
+      <ContinuationForm
+        title="Not quite right? Ask Claude to revise."
+        hint="Describe what to change and get a new slash command. The artifact above is kept as context."
+        cta="Continue"
+        placeholder="e.g. 'redo with a tighter summary'"
+        onSubmit={onContinue}
+      />
+      <InputPanel entity={entity} collapsed />
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/client/EntityDetail.test.tsx`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/pages/EntityDetail.tsx tests/client/EntityDetail.test.tsx
+git commit -m "feat(client): EntityDetail wraps completed artifact in BaseArtifactPanel"
+```
+
+### Task 11: Build `CompanionAbout` page
+
+**Files:**
+- Create: `src/client/pages/CompanionAbout.tsx`
+- Create: `tests/client/CompanionAbout.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/client/CompanionAbout.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import CompanionAbout from "../../src/client/pages/CompanionAbout";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url === "/api/companions") return new Response(JSON.stringify([
+      { name: "demo", kind: "entity", displayName: "Demo", icon: "✨", description: "Demo companion.", contractVersion: "1", version: "0.1.0", requiredEnv: ["DEMO_TOKEN"] },
+    ]), { status: 200 });
+    if (url === "/api/companions/demo/preflight") return new Response(JSON.stringify({
+      ok: false, missingRequired: ["DEMO_TOKEN"], missingOptional: [],
+    }), { status: 200 });
+    if (url === "/api/tools/demo") return new Response(JSON.stringify({
+      manifest: { name: "demo", kind: "entity", displayName: "Demo", icon: "✨", description: "Demo companion.", contractVersion: "1", version: "0.1.0" },
+      tools: [
+        { name: "demo_get_thing", description: "Read a thing.", params: [], signature: "demo_get_thing()", sideEffect: "read" },
+        { name: "demo_post_thing", description: "Post a thing.", params: [], signature: "demo_post_thing()", sideEffect: "write" },
+      ],
+    }), { status: 200 });
+    throw new Error(`unexpected: ${url}`);
+  }));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("CompanionAbout", () => {
+  it("renders manifest header", async () => {
+    render(
+      <MemoryRouter initialEntries={["/c/demo"]}>
+        <Routes>
+          <Route path="/c/:companion" element={<CompanionAbout />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Demo" })).toBeInTheDocument());
+    expect(screen.getByText(/Demo companion/)).toBeInTheDocument();
+  });
+
+  it("renders preflight banner when config missing", async () => {
+    render(
+      <MemoryRouter initialEntries={["/c/demo"]}>
+        <Routes>
+          <Route path="/c/:companion" element={<CompanionAbout />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText("DEMO_TOKEN")).toBeInTheDocument());
+  });
+
+  it("groups tools by sideEffect with write tools flagged", async () => {
+    render(
+      <MemoryRouter initialEntries={["/c/demo"]}>
+        <Routes>
+          <Route path="/c/:companion" element={<CompanionAbout />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText("demo_get_thing")).toBeInTheDocument());
+    expect(screen.getByText("demo_post_thing")).toBeInTheDocument();
+    // write warning visible
+    expect(screen.getByText(/writes to external systems/i)).toBeInTheDocument();
+  });
+
+  it("does NOT show write warning when no write tools", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (url === "/api/companions") return new Response(JSON.stringify([
+        { name: "ro", kind: "entity", displayName: "RO", icon: "🔍", description: "", contractVersion: "1", version: "0.1.0" },
+      ]), { status: 200 });
+      if (url === "/api/companions/ro/preflight") return new Response(JSON.stringify({ ok: true, missingRequired: [], missingOptional: [] }), { status: 200 });
+      if (url === "/api/tools/ro") return new Response(JSON.stringify({
+        manifest: { name: "ro", kind: "entity", displayName: "RO", icon: "🔍", description: "", contractVersion: "1", version: "0.1.0" },
+        tools: [{ name: "ro_get", description: "read", params: [], signature: "ro_get()", sideEffect: "read" }],
+      }), { status: 200 });
+      throw new Error(`unexpected: ${url}`);
+    }));
+    render(
+      <MemoryRouter initialEntries={["/c/ro"]}>
+        <Routes>
+          <Route path="/c/:companion" element={<CompanionAbout />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText("ro_get")).toBeInTheDocument());
+    expect(screen.queryByText(/writes to external systems/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npx vitest run tests/client/CompanionAbout.test.tsx`
+Expected: import error.
+
+- [ ] **Step 3: Implement the page**
+
+Create `src/client/pages/CompanionAbout.tsx`:
+
+```tsx
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import type { Manifest } from "@shared/types";
+import Breadcrumb from "../components/Breadcrumb";
+import PreflightBanner from "../components/PreflightBanner";
+import { fetchCompanions } from "../api";
+
+interface ToolDescriptor {
+  name: string;
+  description: string;
+  params: Array<{ name: string; required?: boolean; description?: string }>;
+  signature: string;
+  sideEffect: "read" | "write";
+}
+
+interface AboutPayload {
+  manifest: Manifest;
+  tools: ToolDescriptor[];
+}
+
+export default function CompanionAbout() {
+  const { companion = "" } = useParams();
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [payload, setPayload] = useState<AboutPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const all = await fetchCompanions();
+        if (!cancelled) setManifest(all.find((m) => m.name === companion) ?? null);
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [companion]);
+
+  useEffect(() => {
+    if (!manifest) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const r = await fetch(`/api/tools/${encodeURIComponent(companion)}`);
+        if (r.status === 400 || r.status === 404) {
+          // Entity-kind doesn't have /api/tools; build payload from manifest only.
+          if (!cancelled) setPayload({ manifest, tools: [] });
+          return;
+        }
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        if (!cancelled) setPayload(await r.json());
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [companion, manifest]);
+
+  if (error) return <div style={{ color: "#dc2626" }}>Failed to load: {error}</div>;
+  if (!manifest || !payload) return <div style={{ color: "var(--muted)" }}>Loading…</div>;
+
+  const writeTools = payload.tools.filter((t) => t.sideEffect === "write");
+  const readTools = payload.tools.filter((t) => t.sideEffect === "read");
+  const hasWrites = writeTools.length > 0;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      <Breadcrumb manifest={manifest} />
+      <header style={{ display: "flex", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+        <span style={{ fontSize: 40 }} aria-hidden="true">{manifest.icon}</span>
+        <div style={{ flex: 1, minWidth: 220 }}>
+          <h1 style={{ margin: 0 }}>{manifest.displayName}</h1>
+          <div style={{ fontSize: 12, color: "var(--muted)", marginTop: 4 }}>
+            claudepanion-{manifest.name} · v{manifest.version}
+            {hasWrites
+              ? <span className="badge badge-write" style={{ marginLeft: 8 }}>writes to external systems</span>
+              : payload.tools.length > 0 && <span className="badge badge-read" style={{ marginLeft: 8 }}>read-only</span>}
+          </div>
+          <p style={{ marginTop: 8, marginBottom: 0 }}>{manifest.description}</p>
+        </div>
+        {manifest.kind === "entity" && (
+          <Link to={`/c/${manifest.name}/new`} className="btn" style={{ whiteSpace: "nowrap" }}>
+            Start a new run
+          </Link>
+        )}
+        <Link to={`/c/${manifest.name}/runs`} className="btn-outline" style={{ whiteSpace: "nowrap" }}>
+          View runs
+        </Link>
+      </header>
+
+      <PreflightBanner companion={companion} />
+
+      {hasWrites && (
+        <div role="alert" className="write-tools-warning">
+          <strong>⚠️ This companion writes to external systems.</strong>
+          <ul style={{ margin: "8px 0 0 20px", fontSize: 13 }}>
+            {writeTools.map((t) => (
+              <li key={t.name}>
+                <code>{t.name}</code> — {t.description}
+              </li>
+            ))}
+          </ul>
+          <div style={{ marginTop: 8, fontSize: 12, color: "var(--muted)" }}>
+            The skill will ask for your permission before each write action.
+          </div>
+        </div>
+      )}
+
+      {payload.tools.length > 0 && (
+        <section>
+          <h2 style={{ marginTop: 0, marginBottom: 12, fontSize: 18 }}>MCP tools</h2>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {[...readTools, ...writeTools].map((t) => (
+              <div key={t.name} style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 12 }}>
+                <code style={{ fontSize: 13, fontWeight: 600 }}>
+                  {t.name}
+                  {t.sideEffect === "write" && <span className="badge badge-write" style={{ marginLeft: 8 }}>write</span>}
+                </code>
+                {t.description && <div style={{ fontSize: 13, color: "var(--muted)", marginTop: 4 }}>{t.description}</div>}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+```
+
+Append CSS to `src/client/styles.css`:
+
+```css
+.badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.badge-read {
+  background: #f1f5f9;
+  color: #475569;
+}
+.badge-write {
+  background: #fee2e2;
+  color: #991b1b;
+}
+.write-tools-warning {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/client/CompanionAbout.test.tsx`
+Expected: all 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/pages/CompanionAbout.tsx tests/client/CompanionAbout.test.tsx src/client/styles.css
+git commit -m "feat(client): CompanionAbout page renders manifest, preflight, and tool list with sideEffect badges"
+```
+
+### Task 12: Update routing — About at `/c/:name`, List at `/c/:name/runs`
+
+**Files:**
+- Modify: `src/client/App.tsx`
+- Modify: `src/client/pages/CompanionRoute.tsx`
+
+- [ ] **Step 1: Add explicit route for runs**
+
+Replace `src/client/App.tsx`:
+
+```tsx
+import { Routes, Route, Navigate } from "react-router-dom";
+import Sidebar from "./components/Sidebar";
+import CompanionRoute from "./pages/CompanionRoute";
+import NewEntity from "./pages/NewEntity";
+import EntityDetail from "./pages/EntityDetail";
+import EntityList from "./pages/EntityList";
+import Install from "./pages/Install";
+
+export default function App() {
+  return (
+    <div className="app">
+      <Sidebar />
+      <main className="app-main">
+        <Routes>
+          <Route path="/" element={<Navigate to="/c/build" replace />} />
+          <Route path="/install" element={<Install />} />
+          <Route path="/c/:companion" element={<CompanionRoute />} />
+          <Route path="/c/:companion/runs" element={<EntityList />} />
+          <Route path="/c/:companion/new" element={<NewEntity />} />
+          <Route path="/c/:companion/:id" element={<EntityDetail />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update `CompanionRoute` to render the new About**
+
+Replace `src/client/pages/CompanionRoute.tsx`:
+
+```tsx
+import { useParams } from "react-router-dom";
+import { useCompanions } from "../hooks/useCompanions";
+import CompanionAbout from "./CompanionAbout";
+
+export default function CompanionRoute() {
+  const { companion } = useParams<{ companion: string }>();
+  const { companions, loading } = useCompanions();
+  if (loading) return <div style={{ color: "var(--muted)" }}>Loading…</div>;
+  const manifest = companions.find((c) => c.name === companion);
+  if (!manifest) return <div style={{ color: "#dc2626" }}>Unknown companion: {companion}</div>;
+  // Both entity and tool kinds now use the unified About page.
+  return <CompanionAbout />;
+}
+```
+
+The `ToolAbout.tsx` file's "Try it" panel functionality should be preserved. Add the Try-it panel from `ToolAbout` into `CompanionAbout` for tool-kind companions:
+
+In `src/client/pages/CompanionAbout.tsx`, import the `TryIt` component (move it from `ToolAbout.tsx` to a shared location or re-export it). Modify the bottom of the rendered JSX:
+
+```tsx
+// Add import at top:
+// (move the TryIt function from ToolAbout.tsx into CompanionAbout.tsx, or extract to a new file)
+
+// Add at end of JSX, before closing </div>:
+{manifest.kind === "tool" && payload.tools.length > 0 && (
+  <TryIt companion={companion} tools={payload.tools} />
+)}
+```
+
+The simplest path: copy the `TryIt` function and `ToolDescriptor` interface inline into `CompanionAbout.tsx`. Alternatively, leave `ToolAbout.tsx` unchanged and route tool kind to `ToolAbout` while entity kind goes to `CompanionAbout`. **Choosing the second option** for minimal diff:
+
+Replace `CompanionRoute.tsx` with:
+
+```tsx
+import { useParams } from "react-router-dom";
+import { useCompanions } from "../hooks/useCompanions";
+import CompanionAbout from "./CompanionAbout";
+import ToolAbout from "./ToolAbout";
+
+export default function CompanionRoute() {
+  const { companion } = useParams<{ companion: string }>();
+  const { companions, loading } = useCompanions();
+  if (loading) return <div style={{ color: "var(--muted)" }}>Loading…</div>;
+  const manifest = companions.find((c) => c.name === companion);
+  if (!manifest) return <div style={{ color: "#dc2626" }}>Unknown companion: {companion}</div>;
+  return manifest.kind === "tool" ? <ToolAbout /> : <CompanionAbout />;
+}
+```
+
+- [ ] **Step 3: Verify Sidebar links still target `/c/:name`**
+
+Read `src/client/components/Sidebar.tsx`:
+
+Run: `grep -n 'to=' src/client/components/Sidebar.tsx`
+Expected: links point to `/c/<name>` already. No change needed unless the sidebar special-cases List vs About.
+
+- [ ] **Step 4: Update existing test that expected EntityList to render at /c/:name**
+
+Search for tests that assume the old behavior:
+
+Run: `grep -rn 'CompanionRoute\|EntityList' tests/client/`
+Expected: identify any tests using `MemoryRouter initialEntries={["/c/<name>"]}` that expect List behavior.
+
+If any exist, update them to use `/c/<name>/runs` instead. The most likely candidate is `tests/client/EntityList.test.tsx` — confirm by reading it. If it uses `<EntityList>` directly (not via routing), no change needed.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `npm test -- --run`
+Expected: all pass.
+
+- [ ] **Step 6: Smoke test in browser**
+
+Run: `npm run build && PORT=3001 npm start &`
+Then open `http://localhost:3001`, click on Build sidebar item — should land on the About page (manifest header, list of tools, "Start a new run" button, "View runs" button).
+Click "View runs" — should land on EntityList at `/c/build/runs`.
+Click "Start a new run" — should land on NewEntity at `/c/build/new`.
+
+Kill background process: `pkill -f "node.*dist"` or whatever PID was returned.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/client/App.tsx src/client/pages/CompanionRoute.tsx
+git commit -m "feat(client): About page is default landing for /c/:name; List moves to /c/:name/runs"
+```
+
+---
+
+## Phase 4 — Skill Templates
+
+### Task 13: Update entity skill template
+
+**Files:**
+- Modify: `companions/build/templates/skill.md`
+
+- [ ] **Step 1: Replace skill template with comprehensive version**
+
+Replace `companions/build/templates/skill.md` entirely:
+
+```markdown
+---
+name: __NAME__-companion
+description: Use when the user pastes "/__NAME__-companion <entity-id>" — runs the __NAME__ companion against one of its pending entities.
+---
+
+# /__NAME__-companion <entity-id>
+
+Execute one __NAME__ entity to completion.
+
+> **CRITICAL — MCP tools ONLY:**
+> - Use the MCP tools prefixed `mcp__claudepanion__` for ALL state changes (status, logs, artifact, failure).
+> - NEVER curl the REST API at `/api/entities/*` to mutate state.
+> - NEVER edit `data/__NAME__/<id>.json` directly.
+> - If an MCP tool returns an error, call `mcp__claudepanion__`__NAME___fail`` and stop. Do NOT fall back to HTTP.
+> - If `mcp__claudepanion__` tools are not available in your session, stop and tell the user to verify `claudepanion plugin install` and that the server is running, then start a new Claude Code session.
+
+## Step 1 — Load the entity
+
+```
+mcp__claudepanion__`__NAME___get`({ id: "<entity-id>" })
+```
+
+If the call errors or the entity is missing, stop.
+
+### Step 1.5 — Detect continuation
+
+If `entity.artifact !== null`, this is a continuation — the user clicked "Continue" on a previously completed run. Read the prior artifact carefully before doing new work. Use updated `entity.input` fields as the user's redirection. Log:
+
+```
+mcp__claudepanion__`__NAME___append_log`({ id: "<entity-id>", message: "Continuing from prior run — reading previous artifact" })
+```
+
+Produce a complete, updated artifact when you save (not a diff).
+
+## Step 2 — Preflight check
+
+Verify the companion's required env vars are set:
+
+```bash
+curl -s http://localhost:3001/api/companions/__NAME__/preflight
+```
+
+If the response shows `missingRequired` non-empty:
+
+```
+mcp__claudepanion__`__NAME___fail`({ id: "<entity-id>", errorMessage: "[config] missing env vars: <list>" })
+```
+
+and stop.
+
+## Step 3 — Mark running
+
+```
+mcp__claudepanion__`__NAME___update_status`({ id: "<entity-id>", status: "running", statusMessage: "starting" })
+```
+
+## Step 4 — Do the work
+
+__DESCRIPTION__
+
+### 4a — Call domain proxy tools for external system access
+
+If this companion has domain proxy tools (defined in `companions/__NAME__/server/tools.ts`), call them to access external systems. These are your primary data source.
+
+```
+mcp__claudepanion__`__NAME___<verb>`({ id: "<entity-id>", ... })
+```
+
+After each proxy tool call, log what you received:
+
+```
+mcp__claudepanion__`__NAME___append_log`({ id: "<entity-id>", message: "fetched 47 records from <source>" })
+```
+
+### 4b — Use Claude's built-in tools for local work (optional)
+
+Use Read, Grep, Bash, and Edit for local file or repository access.
+
+Stream progress after each meaningful step:
+
+```
+mcp__claudepanion__`__NAME___append_log`({ id: "<entity-id>", message: "<what you just did>" })
+mcp__claudepanion__`__NAME___update_status`({ id: "<entity-id>", status: "running", statusMessage: "<current phase>" })
+```
+
+### 4c — Write actions require user permission
+
+If a proxy tool has `sideEffect: "write"` (changes state in an external system), you MUST ask the user before calling it:
+
+1. Show the proposed write content in chat ("Here's the review I'd post to GitHub: …")
+2. Ask: "Should I post this?"
+3. Wait for confirmation
+4. Only call the write tool if confirmed
+5. If declined, save the artifact with `errors: ["user declined write action"]` and proceed to Step 5
+
+Never call a write tool without explicit user permission.
+
+## Step 5 — Save the artifact
+
+The artifact shape is defined by `__PASCAL__Artifact` in `companions/__NAME__/types.ts`. It extends `BaseArtifact` so it may include `summary?: string` and `errors?: string[]`:
+
+```
+mcp__claudepanion__`__NAME___save_artifact`({
+  id: "<entity-id>",
+  artifact: {
+    summary: "<one-line outcome>",
+    errors: [<any [recoverable] errors logged during the run>],
+    // ... your custom artifact fields
+  }
+})
+```
+
+## Step 6 — Complete
+
+```
+mcp__claudepanion__`__NAME___update_status`({ id: "<entity-id>", status: "completed" })
+```
+
+## Error handling
+
+When a proxy tool returns an error, branch on the prefix:
+
+| Prefix | Action |
+|---|---|
+| `[config]` | Call `__NAME___fail` with the error message and stop |
+| `[input]` | Call `__NAME___fail` with the error message and stop |
+| `[transient]` | Log warn, retry the tool ONCE; if still failing, call `__NAME___fail` |
+| `[recoverable]` | Log warn, continue; add the message to the artifact's `errors[]` field |
+| (no prefix) | Treat as fatal: call `__NAME___fail` |
+
+For example:
+
+```
+const result = mcp__claudepanion__`__NAME___fetch_thing`({...})
+if (result.isError) {
+  if (result.content[0].text.startsWith("[transient]")) {
+    // log warn, retry once
+  } else if (result.content[0].text.startsWith("[recoverable]")) {
+    // log warn, add to artifact.errors, continue
+  } else {
+    mcp__claudepanion__`__NAME___fail`({ id, errorMessage: result.content[0].text })
+    // stop
+  }
+}
+```
+
+## On unrecoverable error at any step
+
+```
+mcp__claudepanion__`__NAME___fail`({ id: "<entity-id>", errorMessage: "<short cause>", errorStack: "<optional stack>" })
+```
+```
+
+- [ ] **Step 2: Run all tests to verify nothing broke**
+
+Run: `npm test -- --run`
+Expected: all pass (template changes don't affect runtime tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add companions/build/templates/skill.md
+git commit -m "feat(templates): entity skill template — continuation, preflight, error handling, write permission patterns"
+```
+
+### Task 14: Update Build skill — read-only bias
+
+**Files:**
+- Modify: `skills/build-companion/SKILL.md`
+
+- [ ] **Step 1: Add read-only bias section**
+
+Open `skills/build-companion/SKILL.md` and find Step 2 ("Validate + resolve substitution tokens") under Mode: new-companion.
+
+Add a new step **Step 2.5 — Interpret request: read-only by default** between Step 2 and Step 3:
+
+```markdown
+### Step 2.5 — Interpret the user's request: read-only by default
+
+Read `entity.input.description` and decide what proxy tools to scaffold. Apply this rule:
+
+> **Default to read-only proxy tools unless the user explicitly requests write actions.**
+
+| User wrote… | Action |
+|---|---|
+| "review PRs", "investigate logs", "check Linear", "summarize Slack" | Scaffold READ-only tools |
+| "post a review", "update a ticket", "send a message", "create an alarm" | Scaffold READ tools + the explicitly-requested WRITE tools |
+| Vague description ("PR helper", "incident tool") | Default to READ-only |
+
+When you scaffold write tools, set `sideEffect: "write"` on them. The host's About page will surface a warning, and the entity skill template's Step 4c will require user permission before each call.
+
+When you scaffold read-only tools, omit `sideEffect` (defaults to `"read"`).
+
+If the description mentions an external system (GitHub, AWS, Linear, Slack, etc.), add the relevant env var to the manifest's `requiredEnv`:
+
+| Service | Env var |
+|---|---|
+| GitHub API | `GITHUB_TOKEN` |
+| AWS SDK | (none — uses `~/.aws/credentials`; profile passed as tool arg) |
+| Linear API | `LINEAR_API_KEY` |
+| Slack API | `SLACK_BOT_TOKEN` |
+| OpenAI API | `OPENAI_API_KEY` |
+
+Log:
+
+```
+mcp__claudepanion__build_append_log({ id: "<entity-id>", message: "interpreted as <read-only|with-write> companion using <external-system>" })
+```
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `npm test -- --run`
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/build-companion/SKILL.md
+git commit -m "feat(build-skill): read-only bias when interpreting vague descriptions"
+```
+
+### Task 15: Update entity tools template comment
+
+**Files:**
+- Modify: `companions/build/templates/entity/server/tools.ts`
+
+- [ ] **Step 1: Update template with sideEffect example**
+
+Replace `companions/build/templates/entity/server/tools.ts`:
+
+```ts
+import { z } from "zod";
+import type { CompanionToolDefinition } from "../../../src/shared/types.js";
+import { successResult, errorResult, configErrorResult, transientErrorResult } from "../../../src/shared/types.js";
+
+// Domain proxy tools for __NAME__.
+//
+// Each tool calls an external API using locally-stored credentials.
+// The host auto-registers the six generic entity tools (_get, _list,
+// _update_status, _append_log, _save_artifact, _fail) — don't add them here.
+//
+// Every tool name must be prefixed "__NAME___".
+// Set sideEffect: "write" on tools that change external state — the skill
+// will require user permission before each call.
+
+export const tools: CompanionToolDefinition[] = [
+  // Read-only example (sideEffect defaults to "read"):
+  //
+  // {
+  //   name: "__NAME___fetch",
+  //   description: "Fetch data from the external service.",
+  //   schema: {
+  //     id: z.string().describe("entity ID"),
+  //     query: z.string().describe("query to send to the external API"),
+  //   },
+  //   async handler({ id, query }: { id: string; query: string }) {
+  //     const token = process.env.SERVICE_TOKEN;
+  //     if (!token) return configErrorResult("SERVICE_TOKEN", "create a token at example.com/tokens");
+  //     try {
+  //       const data = await fetch("https://api.example.com/...").then((r) => r.json());
+  //       return successResult(data);
+  //     } catch (err: any) {
+  //       if (err.code === "ECONNREFUSED") return transientErrorResult(`network error: ${err.message}`);
+  //       return errorResult(`API error: ${err.message}`);
+  //     }
+  //   },
+  // },
+  //
+  // Write example (sideEffect: "write" — skill prompts for permission):
+  //
+  // {
+  //   name: "__NAME___create",
+  //   description: "Create a new resource. Visible to other users; cannot be deleted.",
+  //   schema: { id: z.string(), title: z.string() },
+  //   sideEffect: "write",
+  //   async handler({ id, title }: { id: string; title: string }) {
+  //     // ... call API
+  //     return successResult({ ok: true });
+  //   },
+  // },
+];
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `npm test -- --run`
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add companions/build/templates/entity/server/tools.ts
+git commit -m "feat(templates): scaffold tools.ts shows read and write patterns with new helpers"
+```
+
+### Task 16: Update scaffold spec to mark items shipped
+
+**Files:**
+- Modify: `docs/scaffold-spec.md`
+
+- [ ] **Step 1: Update the implementation status table**
+
+In `docs/scaffold-spec.md`, find the implementation status table at the bottom. Update each row that this PR shipped:
+
+```markdown
+| 3. Manifest `requiredEnv`/`optionalEnv` | ✅ Shipped |
+| 4. Configuration & preflight | ✅ Shipped (endpoint + banner) |
+| 5. Form contract | ✅ Shipped (form + preflight banner integration) |
+| 7. Skill template | ✅ Shipped (continuation + preflight + error handling + write-permission stanzas) |
+| 7d. Continuation contract | ✅ Shipped (skill template stanza) |
+| 9e. Write-action safety | ✅ Shipped (sideEffect flag + skill pattern + About warning) |
+| 10. Error handling helpers | ✅ Shipped (configErrorResult/inputErrorResult/transientErrorResult) |
+| 10. Skill error pattern | ✅ Shipped (template additions) |
+| 10. Artifact `errors[]` convention | ✅ Shipped (BaseArtifact + BaseArtifactPanel) |
+| 11. Artifact rendering | ✅ Shipped (BaseArtifactPanel wrapper) |
+| 11.5. BaseArtifact interface | ✅ Shipped |
+| 12c. About page (entity kind) | ✅ Shipped (CompanionAbout) |
+| 13d. External dependencies | ✅ Convention documented |
+| 14. Validator / smoke / watcher | ✅ Shipped (validator accepts new manifest fields) |
+```
+
+Replace the "Foundation work to land before chip examples" section with:
+
+```markdown
+**Foundation shipped:** Phase 1–4 of `docs/superpowers/plans/2026-04-25-scaffold-foundation.md` complete.
+
+**Remaining for chip examples:**
+
+1. Build's first read-only proxy companion (e.g., GitHub PR reviewer) using the new primitives
+2. End-to-end verification — scaffold a companion with `requiredEnv`, run preflight check, verify About page rendering, simulate a run with a recoverable error
+```
+
+Also add a new subsection §11.5 about `BaseArtifact` between §11a (Artifact type) and §11b (Detail rendering):
+
+```markdown
+### 11.5. The `BaseArtifact` interface
+
+Every companion's artifact type should extend `BaseArtifact`:
+
+```ts
+export interface BaseArtifact {
+  /** Short one-liner describing the run's outcome. Shown in List row + Detail header. */
+  summary?: string;
+  /** Recoverable issues during the run. Rendered as "Notes during this run" by the host. */
+  errors?: string[];
+}
+```
+
+The host wraps every Detail page renderer in `<BaseArtifactPanel>` which automatically renders `summary` (top banner) and `errors[]` (bottom section). Companion authors only render their domain-specific middle content.
+
+Companions can make `summary` required by overriding the type in the extended interface (e.g., `BuildArtifact.summary: string`).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/scaffold-spec.md
+git commit -m "docs: scaffold spec reflects foundation shipped; BaseArtifact section added"
+```
+
+---
+
+## Final verification
+
+### Task 17: End-to-end smoke test
+
+- [ ] **Step 1: Build and run the server**
+
+```bash
+npm run build
+PORT=3001 npm start &
+sleep 3
+```
+
+- [ ] **Step 2: Verify endpoints**
+
+```bash
+# Build companion has no requiredEnv, so preflight should be ok:true
+curl -s http://localhost:3001/api/companions/build/preflight | jq
+# Expected: { "ok": true, "missingRequired": [], "missingOptional": [] }
+
+# Tools endpoint includes sideEffect (currently empty array for build's tools)
+curl -s http://localhost:3001/api/tools/build | jq
+# Expected: 400 (build is entity kind), or tools array with sideEffect on each
+```
+
+- [ ] **Step 3: Verify UI**
+
+Open `http://localhost:3001` in browser:
+- Default landing → About page for build
+- Click "Start a new run" → form renders with no preflight banner (no requiredEnv)
+- Submit a Build form → goes to detail page, slash command shown
+- (Manual) Run the slash command in Claude Code, verify the new skill template steps work end-to-end
+
+- [ ] **Step 4: Stop the server**
+
+```bash
+pkill -f "node.*dist/src/server"
+```
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+npm test -- --run && npm run check && npm run build
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Push the branch**
+
+```bash
+git push -u origin feat/scaffold-foundation
+```
+
+- [ ] **Step 7: Open PR**
+
+```bash
+gh pr create --title "Scaffold foundation: preflight, error helpers, BaseArtifact, About page, write-action safety" --body "$(cat <<'EOF'
+## Summary
+
+Foundation primitives for proxy companions, satisfying `docs/scaffold-spec.md`.
+
+- **Manifest `requiredEnv` / `optionalEnv`** — companions declare their env-var dependencies
+- **`GET /api/companions/:name/preflight`** — generic config-readiness check
+- **`<PreflightBanner>`** — auto-renders blocking/soft banners on the New Entity form (and About page)
+- **Error helpers** — `configErrorResult`, `inputErrorResult`, `transientErrorResult` standardize the four error classes
+- **`CompanionToolDefinition.sideEffect`** — `"read" | "write"` flag drives About page warnings and skill permission flow
+- **`BaseArtifact`** — common artifact fields (`summary?`, `errors?`) with `<BaseArtifactPanel>` doing generic rendering
+- **`<CompanionAbout>` page** — default landing at `/c/:name`; List moves to `/c/:name/runs`
+- **Skill template updates** — continuation detection, preflight check, four-class error handling, write-permission stanza
+- **Build skill read-only bias** — when interpreting vague descriptions, default to read-only
+
+## Test plan
+
+- [ ] All vitest tests pass (`npm test`)
+- [ ] Typecheck passes (`npm run check`)
+- [ ] Build passes (`npm run build`)
+- [ ] Manual: open http://localhost:3001, verify About page is the default landing
+- [ ] Manual: scaffold a Build run, verify the new skill template steps work in Claude Code
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** Phase 1 covers manifest fields, sideEffect, BaseArtifact, helpers. Phase 2 covers preflight + banner. Phase 3 covers About page, BaseArtifactPanel, routing. Phase 4 covers skill template + Build bias. All ✅ items in the spec's implementation status table are covered.
+
+**Type consistency:** `PreflightStatus` defined once in `usePreflight.ts`; `BaseArtifact` defined once in `shared/types.ts`; `BuildArtifact extends BaseArtifact`; all components consistently reference the same interfaces.
+
+**Test commands:** `npm test -- --run` runs full suite; `npx vitest run <path>` runs targeted tests. Both work in this codebase.

--- a/skills/build-companion/SKILL.md
+++ b/skills/build-companion/SKILL.md
@@ -56,6 +56,38 @@ Compute substitution tokens. This is mechanical — apply exactly:
 | `__ICON__` | one emoji that fits `description` | `🔎` |
 | `__DESCRIPTION__` | `entity.input.description` collapsed to one line | `Review a PR in this repo…` |
 
+### Step 2.5 — Interpret the user's request: read-only by default
+
+Read `entity.input.description` and decide what proxy tools to scaffold. Apply this rule:
+
+> **Default to read-only proxy tools unless the user explicitly requests write actions.**
+
+| User wrote… | Action |
+|---|---|
+| "review PRs", "investigate logs", "check Linear", "summarize Slack" | Scaffold READ-only tools |
+| "post a review", "update a ticket", "send a message", "create an alarm" | Scaffold READ tools + the explicitly-requested WRITE tools |
+| Vague description ("PR helper", "incident tool") | Default to READ-only |
+
+When you scaffold write tools, set `sideEffect: "write"` on them. The host's About page will surface a warning, and the entity skill template's Step 4c will require user permission before each call.
+
+When you scaffold read-only tools, omit `sideEffect` (defaults to `"read"`).
+
+If the description mentions an external system (GitHub, AWS, Linear, Slack, etc.), add the relevant env var to the manifest's `requiredEnv`:
+
+| Service | Env var |
+|---|---|
+| GitHub API | `GITHUB_TOKEN` |
+| AWS SDK | (none — uses `~/.aws/credentials`; profile passed as tool arg) |
+| Linear API | `LINEAR_API_KEY` |
+| Slack API | `SLACK_BOT_TOKEN` |
+| OpenAI API | `OPENAI_API_KEY` |
+
+Log:
+
+```
+mcp__claudepanion__build_append_log({ id: "<entity-id>", message: "interpreted as <read-only|with-write> companion using <external-system>" })
+```
+
 ### Step 3 — Mark running
 
 ```

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -3,6 +3,7 @@ import Sidebar from "./components/Sidebar";
 import CompanionRoute from "./pages/CompanionRoute";
 import NewEntity from "./pages/NewEntity";
 import EntityDetail from "./pages/EntityDetail";
+import EntityList from "./pages/EntityList";
 import Install from "./pages/Install";
 
 export default function App() {
@@ -14,6 +15,7 @@ export default function App() {
           <Route path="/" element={<Navigate to="/c/build" replace />} />
           <Route path="/install" element={<Install />} />
           <Route path="/c/:companion" element={<CompanionRoute />} />
+          <Route path="/c/:companion/runs" element={<EntityList />} />
           <Route path="/c/:companion/new" element={<NewEntity />} />
           <Route path="/c/:companion/:id" element={<EntityDetail />} />
         </Routes>

--- a/src/client/components/BaseArtifactPanel.tsx
+++ b/src/client/components/BaseArtifactPanel.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import type { Entity } from "@shared/types";
+
+export interface BaseArtifactPanelProps {
+  entity: Entity;
+  children: ReactNode;
+}
+
+interface PartialBase {
+  summary?: unknown;
+  errors?: unknown;
+}
+
+export default function BaseArtifactPanel({ entity, children }: BaseArtifactPanelProps) {
+  const a = (entity.artifact ?? {}) as PartialBase;
+  const summary = typeof a.summary === "string" && a.summary.trim() ? a.summary : null;
+  const errors = Array.isArray(a.errors) ? a.errors.filter((e): e is string => typeof e === "string") : [];
+
+  return (
+    <>
+      {summary && (
+        <div className="artifact-summary-banner">
+          {summary}
+        </div>
+      )}
+      {children}
+      {errors.length > 0 && (
+        <div className="artifact-errors">
+          <div className="artifact-errors-header">Notes during this run</div>
+          <ul className="artifact-errors-list">
+            {errors.map((e, i) => (<li key={i}>{e}</li>))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/client/components/PreflightBanner.tsx
+++ b/src/client/components/PreflightBanner.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { usePreflight } from "../hooks/usePreflight";
+
+export interface PreflightBannerProps {
+  companion: string;
+  /** Called whenever the preflight status changes. Useful for the parent form to disable submit. */
+  onStatus?: (s: { blocked: boolean; missingRequired: string[]; missingOptional: string[] }) => void;
+}
+
+export default function PreflightBanner({ companion, onStatus }: PreflightBannerProps) {
+  const status = usePreflight(companion);
+
+  useEffect(() => {
+    if (status.loading) return;
+    onStatus?.({
+      blocked: !status.ok,
+      missingRequired: status.missingRequired,
+      missingOptional: status.missingOptional,
+    });
+  }, [status.loading, status.ok, status.missingRequired, status.missingOptional, onStatus]);
+
+  if (status.loading) return null;
+  if (status.ok && status.missingOptional.length === 0) return null;
+
+  if (!status.ok) {
+    return (
+      <div role="alert" className="preflight-banner preflight-banner-blocking">
+        <strong>⚠️ Configuration required.</strong>{" "}
+        This companion needs the following environment {status.missingRequired.length === 1 ? "variable" : "variables"} to run:
+        <ul style={{ margin: "8px 0 0 20px" }}>
+          {status.missingRequired.map((v) => (<li key={v}><code>{v}</code></li>))}
+        </ul>
+        <div style={{ marginTop: 8, fontSize: 12, color: "var(--muted)" }}>
+          Set them in your environment, then reload this page.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div role="status" className="preflight-banner preflight-banner-soft">
+      <strong>Optional config not set.</strong>{" "}
+      Some features may be limited:
+      <ul style={{ margin: "8px 0 0 20px" }}>
+        {status.missingOptional.map((v) => (<li key={v}><code>{v}</code></li>))}
+      </ul>
+    </div>
+  );
+}

--- a/src/client/components/PreflightBanner.tsx
+++ b/src/client/components/PreflightBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePreflight } from "../hooks/usePreflight";
 
 export interface PreflightBannerProps {
@@ -9,15 +9,17 @@ export interface PreflightBannerProps {
 
 export default function PreflightBanner({ companion, onStatus }: PreflightBannerProps) {
   const status = usePreflight(companion);
+  const onStatusRef = useRef(onStatus);
+  onStatusRef.current = onStatus;
 
   useEffect(() => {
     if (status.loading) return;
-    onStatus?.({
+    onStatusRef.current?.({
       blocked: !status.ok,
       missingRequired: status.missingRequired,
       missingOptional: status.missingOptional,
     });
-  }, [status.loading, status.ok, status.missingRequired, status.missingOptional, onStatus]);
+  }, [status.loading, status.ok, status.missingRequired, status.missingOptional]);
 
   if (status.loading) return null;
   if (status.ok && status.missingOptional.length === 0) return null;

--- a/src/client/hooks/usePreflight.ts
+++ b/src/client/hooks/usePreflight.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+export interface PreflightStatus {
+  ok: boolean;
+  missingRequired: string[];
+  missingOptional: string[];
+  loading: boolean;
+}
+
+const INITIAL: PreflightStatus = { ok: true, missingRequired: [], missingOptional: [], loading: true };
+
+export function usePreflight(companion: string | undefined): PreflightStatus {
+  const [status, setStatus] = useState<PreflightStatus>(INITIAL);
+
+  useEffect(() => {
+    if (!companion) return;
+    let cancelled = false;
+    setStatus(INITIAL);
+    void (async () => {
+      try {
+        const r = await fetch(`/api/companions/${encodeURIComponent(companion)}/preflight`);
+        if (cancelled) return;
+        if (r.status === 404) {
+          // Treat as no preflight requirement — backwards-compatible.
+          setStatus({ ok: true, missingRequired: [], missingOptional: [], loading: false });
+          return;
+        }
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const data = await r.json();
+        setStatus({ ...data, loading: false });
+      } catch {
+        if (!cancelled) setStatus({ ok: true, missingRequired: [], missingOptional: [], loading: false });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [companion]);
+
+  return status;
+}

--- a/src/client/pages/CompanionAbout.tsx
+++ b/src/client/pages/CompanionAbout.tsx
@@ -97,7 +97,7 @@ export default function CompanionAbout() {
           <ul style={{ margin: "8px 0 0 20px", fontSize: 13 }}>
             {writeTools.map((t) => (
               <li key={t.name}>
-                Tool {t.name} — {t.description}
+                <code>{t.name}</code> — {t.description}
               </li>
             ))}
           </ul>

--- a/src/client/pages/CompanionAbout.tsx
+++ b/src/client/pages/CompanionAbout.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import type { Manifest } from "@shared/types";
+import Breadcrumb from "../components/Breadcrumb";
+import PreflightBanner from "../components/PreflightBanner";
+import { fetchCompanions } from "../api";
+
+interface ToolDescriptor {
+  name: string;
+  description: string;
+  params: Array<{ name: string; required?: boolean; description?: string }>;
+  signature: string;
+  sideEffect: "read" | "write";
+}
+
+interface AboutPayload {
+  manifest: Manifest;
+  tools: ToolDescriptor[];
+}
+
+export default function CompanionAbout() {
+  const { companion = "" } = useParams();
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [payload, setPayload] = useState<AboutPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const all = await fetchCompanions();
+        if (!cancelled) setManifest(all.find((m) => m.name === companion) ?? null);
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [companion]);
+
+  useEffect(() => {
+    if (!manifest) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const r = await fetch(`/api/tools/${encodeURIComponent(companion)}`);
+        if (r.status === 400 || r.status === 404) {
+          // Entity-kind doesn't have /api/tools; build payload from manifest only.
+          if (!cancelled) setPayload({ manifest, tools: [] });
+          return;
+        }
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        if (!cancelled) setPayload(await r.json());
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [companion, manifest]);
+
+  if (error) return <div style={{ color: "#dc2626" }}>Failed to load: {error}</div>;
+  if (!manifest || !payload) return <div style={{ color: "var(--muted)" }}>Loading…</div>;
+
+  const writeTools = payload.tools.filter((t) => t.sideEffect === "write");
+  const readTools = payload.tools.filter((t) => t.sideEffect === "read");
+  const hasWrites = writeTools.length > 0;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      <Breadcrumb manifest={manifest} />
+      <header style={{ display: "flex", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+        <span style={{ fontSize: 40 }} aria-hidden="true">{manifest.icon}</span>
+        <div style={{ flex: 1, minWidth: 220 }}>
+          <h1 style={{ margin: 0 }}>{manifest.displayName}</h1>
+          <div style={{ fontSize: 12, color: "var(--muted)", marginTop: 4 }}>
+            claudepanion-{manifest.name} · v{manifest.version}
+            {hasWrites
+              ? <span className="badge badge-write" style={{ marginLeft: 8 }}>writes</span>
+              : payload.tools.length > 0 && <span className="badge badge-read" style={{ marginLeft: 8 }}>read-only</span>}
+          </div>
+          <p style={{ marginTop: 8, marginBottom: 0 }}>{manifest.description}</p>
+        </div>
+        {manifest.kind === "entity" && (
+          <Link to={`/c/${manifest.name}/new`} className="btn" style={{ whiteSpace: "nowrap" }}>
+            Start a new run
+          </Link>
+        )}
+        <Link to={`/c/${manifest.name}/runs`} className="btn-outline" style={{ whiteSpace: "nowrap" }}>
+          View runs
+        </Link>
+      </header>
+
+      <PreflightBanner companion={companion} />
+
+      {hasWrites && (
+        <div role="alert" className="write-tools-warning">
+          <strong>⚠️ This companion writes to external systems.</strong>
+          <ul style={{ margin: "8px 0 0 20px", fontSize: 13 }}>
+            {writeTools.map((t) => (
+              <li key={t.name}>
+                Tool {t.name} — {t.description}
+              </li>
+            ))}
+          </ul>
+          <div style={{ marginTop: 8, fontSize: 12, color: "var(--muted)" }}>
+            The skill will ask for your permission before each write action.
+          </div>
+        </div>
+      )}
+
+      {payload.tools.length > 0 && (
+        <section>
+          <h2 style={{ marginTop: 0, marginBottom: 12, fontSize: 18 }}>MCP tools</h2>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {[...readTools, ...writeTools].map((t) => (
+              <div key={t.name} style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 12 }}>
+                <code style={{ fontSize: 13, fontWeight: 600 }}>{t.name}</code>
+                {t.sideEffect === "write" && <span className="badge badge-write" style={{ marginLeft: 8 }}>write</span>}
+                {t.description && <div style={{ fontSize: 13, color: "var(--muted)", marginTop: 4 }}>{t.description}</div>}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/client/pages/CompanionRoute.tsx
+++ b/src/client/pages/CompanionRoute.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useCompanions } from "../hooks/useCompanions";
-import EntityList from "./EntityList";
+import CompanionAbout from "./CompanionAbout";
 import ToolAbout from "./ToolAbout";
 
 export default function CompanionRoute() {
@@ -9,5 +9,5 @@ export default function CompanionRoute() {
   if (loading) return <div style={{ color: "var(--muted)" }}>Loading…</div>;
   const manifest = companions.find((c) => c.name === companion);
   if (!manifest) return <div style={{ color: "#dc2626" }}>Unknown companion: {companion}</div>;
-  return manifest.kind === "tool" ? <ToolAbout /> : <EntityList />;
+  return manifest.kind === "tool" ? <ToolAbout /> : <CompanionAbout />;
 }

--- a/src/client/pages/EntityDetail.tsx
+++ b/src/client/pages/EntityDetail.tsx
@@ -8,6 +8,7 @@ import LogsPanel from "../components/LogsPanel";
 import ContinuationForm from "../components/ContinuationForm";
 import StaleBadge from "../components/StaleBadge";
 import Breadcrumb from "../components/Breadcrumb";
+import BaseArtifactPanel from "../components/BaseArtifactPanel";
 import { continueEntity, fetchCompanions } from "../api";
 import type { Entity, Manifest } from "@shared/types";
 import { getArtifactRenderer } from "../../../companions/client";
@@ -124,7 +125,9 @@ function CompletedBody({ entity, onContinue }: { entity: Entity; onContinue: (te
           <div className="artifact-hero-title">Completed</div>
         </div>
         <div className="artifact-hero-body">
-          {Renderer ? <Renderer entity={entity} /> : <pre>{JSON.stringify(entity.artifact, null, 2)}</pre>}
+          <BaseArtifactPanel entity={entity}>
+            {Renderer ? <Renderer entity={entity} /> : <pre>{JSON.stringify(entity.artifact, null, 2)}</pre>}
+          </BaseArtifactPanel>
         </div>
       </div>
       <ContinuationForm

--- a/src/client/pages/NewEntity.tsx
+++ b/src/client/pages/NewEntity.tsx
@@ -4,11 +4,13 @@ import type { Manifest } from "@shared/types";
 import { createEntity, fetchCompanions } from "../api";
 import { getForm } from "../../../companions/client";
 import Breadcrumb from "../components/Breadcrumb";
+import PreflightBanner from "../components/PreflightBanner";
 
 export default function NewEntity() {
   const { companion = "" } = useParams();
   const navigate = useNavigate();
   const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [blocked, setBlocked] = useState(false);
 
   useEffect(() => {
     void fetchCompanions().then((all) => setManifest(all.find((m) => m.name === companion) ?? null));
@@ -23,10 +25,14 @@ export default function NewEntity() {
     <>
       <Breadcrumb manifest={manifest} trailing="New" />
       <div className="page-title"><h1>{companion === "build" ? "New companion" : "New entry"}</h1></div>
-      <Form onSubmit={async (input) => {
-        const e = await createEntity(companion, input);
-        navigate(`/c/${companion}/${e.id}`);
-      }} />
+      <PreflightBanner companion={companion} onStatus={(s) => setBlocked(s.blocked)} />
+      <fieldset disabled={blocked} style={{ border: "none", padding: 0, margin: 0 }}>
+        <Form onSubmit={async (input) => {
+          if (blocked) return;
+          const e = await createEntity(companion, input);
+          navigate(`/c/${companion}/${e.id}`);
+        }} />
+      </fieldset>
     </>
   );
 }

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -132,3 +132,25 @@ textarea:focus-visible,
 .artifact-hero-label { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #166534; }
 .artifact-hero-title { font-size: 14px; color: #14532d; margin-top: 2px; }
 .artifact-hero-body { padding: 18px; }
+
+.preflight-banner {
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+.preflight-banner-blocking {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+}
+.preflight-banner-soft {
+  background: #fefce8;
+  border: 1px solid #fde68a;
+  color: #854d0e;
+}
+.preflight-banner code {
+  background: rgba(0, 0, 0, 0.05);
+  padding: 1px 6px;
+  border-radius: 4px;
+}

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -182,3 +182,29 @@ textarea:focus-visible,
   font-size: 13px;
   color: #713f12;
 }
+
+.badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.badge-read {
+  background: #f1f5f9;
+  color: #475569;
+}
+.badge-write {
+  background: #fee2e2;
+  color: #991b1b;
+}
+.write-tools-warning {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+}

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -154,3 +154,31 @@ textarea:focus-visible,
   padding: 1px 6px;
   border-radius: 4px;
 }
+.artifact-summary-banner {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #14532d;
+  padding: 10px 14px;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  font-size: 14px;
+}
+.artifact-errors {
+  background: #fefce8;
+  border: 1px solid #fde68a;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-top: 12px;
+}
+.artifact-errors-header {
+  font-weight: 600;
+  font-size: 13px;
+  color: #854d0e;
+  margin-bottom: 6px;
+}
+.artifact-errors-list {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 13px;
+  color: #713f12;
+}

--- a/src/server/api-routes.ts
+++ b/src/server/api-routes.ts
@@ -81,6 +81,7 @@ export function mountApiRoutes(app: Express, { store, registry, reliability }: A
         description: (schema as any)._def?.description ?? "",
       })),
       signature: signatureFromDef(def),
+      sideEffect: def.sideEffect ?? "read",
     }));
     res.json({ manifest: c.manifest, tools: descriptors });
   });

--- a/src/server/api-routes.ts
+++ b/src/server/api-routes.ts
@@ -28,6 +28,17 @@ export function mountApiRoutes(app: Express, { store, registry, reliability }: A
     res.json(registry.list().map((c) => c.manifest));
   });
 
+  app.get("/api/companions/:name/preflight", (req: Request, res: Response) => {
+    const name = String(req.params.name);
+    const c = registry.get(name);
+    if (!c) return res.status(404).json({ error: `unknown companion: ${name}` });
+    const requiredEnv = c.manifest.requiredEnv ?? [];
+    const optionalEnv = c.manifest.optionalEnv ?? [];
+    const missingRequired = requiredEnv.filter((v) => !process.env[v]);
+    const missingOptional = optionalEnv.filter((v) => !process.env[v]);
+    res.json({ ok: missingRequired.length === 0, missingRequired, missingOptional });
+  });
+
   app.get("/api/entities", async (req: Request, res: Response) => {
     const companion = String(req.query.companion ?? "");
     if (!companion) return res.status(400).json({ error: "companion query param required" });

--- a/src/server/reliability/validator.ts
+++ b/src/server/reliability/validator.ts
@@ -74,6 +74,17 @@ export function validateCompanion(args: {
     }
   }
 
+  for (const field of ["requiredEnv", "optionalEnv"] as const) {
+    const v = (m as any)[field];
+    if (v !== undefined && (!Array.isArray(v) || v.some((x) => typeof x !== "string"))) {
+      issues.push({
+        code: `manifest.${field}.invalid`,
+        message: `${field} must be a string[] when present`,
+        fatal: false,
+      });
+    }
+  }
+
   if (m.kind === "entity" && args.module?.tools) {
     const prefix = `${m.name}_`;
     for (const def of args.module.tools) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,6 +22,17 @@ export interface Entity<Input = unknown, Artifact = unknown> {
   logs: LogEntry[];
 }
 
+/**
+ * Common fields every artifact may carry. Companions should extend this
+ * interface for their specific Artifact type.
+ */
+export interface BaseArtifact {
+  /** Short one-liner describing the run's outcome. Shown in the List row and Detail header. */
+  summary?: string;
+  /** Recoverable issues encountered during the run. Rendered as a "Notes during this run" section by the host. */
+  errors?: string[];
+}
+
 export type CompanionKind = "entity" | "tool";
 
 export interface Manifest {
@@ -32,6 +43,10 @@ export interface Manifest {
   description: string;
   contractVersion: string;
   version: string;
+  /** Env vars the companion requires. Preflight surfaces missing values; form blocks submission. */
+  requiredEnv?: string[];
+  /** Env vars that enable extra features but aren't required. Preflight surfaces as soft warning. */
+  optionalEnv?: string[];
 }
 
 // ─── MCP tool contract ───────────────────────────────────────────────────────
@@ -51,6 +66,18 @@ export function successResult(data: unknown): McpToolResult {
 
 export function errorResult(message: string): McpToolResult {
   return { content: [{ type: "text", text: message }], isError: true };
+}
+
+export function configErrorResult(envVar: string, hint?: string): McpToolResult {
+  return errorResult(`[config] ${envVar} is not set${hint ? ` — ${hint}` : ""}`);
+}
+
+export function inputErrorResult(message: string): McpToolResult {
+  return errorResult(`[input] ${message}`);
+}
+
+export function transientErrorResult(message: string): McpToolResult {
+  return errorResult(`[transient] ${message}`);
 }
 
 /**
@@ -79,5 +106,8 @@ export interface CompanionToolDefinition<
   description: string;
   /** Zod raw shape — passed to z.object() for MCP schema registration. */
   schema: z.ZodRawShape;
+  /** Defaults to "read". Set to "write" for tools that change state in external systems —
+   *  triggers permission-prompt flow in the skill and a warning badge on the About page. */
+  sideEffect?: "read" | "write";
   handler: (params: TParams) => Promise<McpToolResult>;
 }

--- a/tests/client/BaseArtifactPanel.test.tsx
+++ b/tests/client/BaseArtifactPanel.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import BaseArtifactPanel from "../../src/client/components/BaseArtifactPanel";
+
+const baseEntity = {
+  id: "x-123",
+  companion: "x",
+  status: "completed" as const,
+  statusMessage: null,
+  createdAt: "2026-04-25T00:00:00Z",
+  updatedAt: "2026-04-25T00:00:01Z",
+  input: {},
+  errorMessage: null,
+  errorStack: null,
+  logs: [],
+};
+
+describe("BaseArtifactPanel", () => {
+  it("renders summary banner when artifact has summary", () => {
+    render(
+      <BaseArtifactPanel entity={{ ...baseEntity, artifact: { summary: "All good" } }}>
+        <div>custom-content</div>
+      </BaseArtifactPanel>
+    );
+    expect(screen.getByText("All good")).toBeInTheDocument();
+    expect(screen.getByText("custom-content")).toBeInTheDocument();
+  });
+
+  it("renders errors section when artifact has errors", () => {
+    render(
+      <BaseArtifactPanel entity={{ ...baseEntity, artifact: { errors: ["one failed", "two failed"] } }}>
+        <div>custom-content</div>
+      </BaseArtifactPanel>
+    );
+    expect(screen.getByText("Notes during this run")).toBeInTheDocument();
+    expect(screen.getByText("one failed")).toBeInTheDocument();
+    expect(screen.getByText("two failed")).toBeInTheDocument();
+  });
+
+  it("renders only children when artifact has no summary or errors", () => {
+    render(
+      <BaseArtifactPanel entity={{ ...baseEntity, artifact: { somethingElse: 1 } }}>
+        <div>custom-content</div>
+      </BaseArtifactPanel>
+    );
+    expect(screen.queryByText("Notes during this run")).not.toBeInTheDocument();
+    expect(screen.getByText("custom-content")).toBeInTheDocument();
+  });
+
+  it("renders only children when artifact is null", () => {
+    render(
+      <BaseArtifactPanel entity={{ ...baseEntity, artifact: null }}>
+        <div>custom-content</div>
+      </BaseArtifactPanel>
+    );
+    expect(screen.getByText("custom-content")).toBeInTheDocument();
+  });
+});

--- a/tests/client/CompanionAbout.test.tsx
+++ b/tests/client/CompanionAbout.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import CompanionAbout from "../../src/client/pages/CompanionAbout";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url === "/api/companions") return new Response(JSON.stringify([
+      { name: "demo", kind: "entity", displayName: "Demo", icon: "✨", description: "Demo companion.", contractVersion: "1", version: "0.1.0", requiredEnv: ["DEMO_TOKEN"] },
+    ]), { status: 200 });
+    if (url === "/api/companions/demo/preflight") return new Response(JSON.stringify({
+      ok: false, missingRequired: ["DEMO_TOKEN"], missingOptional: [],
+    }), { status: 200 });
+    if (url === "/api/tools/demo") return new Response(JSON.stringify({
+      manifest: { name: "demo", kind: "entity", displayName: "Demo", icon: "✨", description: "Demo companion.", contractVersion: "1", version: "0.1.0" },
+      tools: [
+        { name: "demo_get_thing", description: "Read a thing.", params: [], signature: "demo_get_thing()", sideEffect: "read" },
+        { name: "demo_post_thing", description: "Post a thing.", params: [], signature: "demo_post_thing()", sideEffect: "write" },
+      ],
+    }), { status: 200 });
+    throw new Error(`unexpected: ${url}`);
+  }));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("CompanionAbout", () => {
+  it("renders manifest header", async () => {
+    render(
+      <MemoryRouter initialEntries={["/c/demo"]}>
+        <Routes>
+          <Route path="/c/:companion" element={<CompanionAbout />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Demo" })).toBeInTheDocument());
+    expect(screen.getByText(/Demo companion/)).toBeInTheDocument();
+  });
+
+  it("renders preflight banner when config missing", async () => {
+    render(
+      <MemoryRouter initialEntries={["/c/demo"]}>
+        <Routes>
+          <Route path="/c/:companion" element={<CompanionAbout />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText("DEMO_TOKEN")).toBeInTheDocument());
+  });
+
+  it("groups tools by sideEffect with write tools flagged", async () => {
+    render(
+      <MemoryRouter initialEntries={["/c/demo"]}>
+        <Routes>
+          <Route path="/c/:companion" element={<CompanionAbout />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText("demo_get_thing")).toBeInTheDocument());
+    expect(screen.getByText("demo_post_thing")).toBeInTheDocument();
+    // write warning visible
+    expect(screen.getByText(/writes to external systems/i)).toBeInTheDocument();
+  });
+
+  it("does NOT show write warning when no write tools", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (url === "/api/companions") return new Response(JSON.stringify([
+        { name: "ro", kind: "entity", displayName: "RO", icon: "🔍", description: "", contractVersion: "1", version: "0.1.0" },
+      ]), { status: 200 });
+      if (url === "/api/companions/ro/preflight") return new Response(JSON.stringify({ ok: true, missingRequired: [], missingOptional: [] }), { status: 200 });
+      if (url === "/api/tools/ro") return new Response(JSON.stringify({
+        manifest: { name: "ro", kind: "entity", displayName: "RO", icon: "🔍", description: "", contractVersion: "1", version: "0.1.0" },
+        tools: [{ name: "ro_get", description: "read", params: [], signature: "ro_get()", sideEffect: "read" }],
+      }), { status: 200 });
+      throw new Error(`unexpected: ${url}`);
+    }));
+    render(
+      <MemoryRouter initialEntries={["/c/ro"]}>
+        <Routes>
+          <Route path="/c/:companion" element={<CompanionAbout />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText("ro_get")).toBeInTheDocument());
+    expect(screen.queryByText(/writes to external systems/i)).not.toBeInTheDocument();
+  });
+});

--- a/tests/client/CompanionAbout.test.tsx
+++ b/tests/client/CompanionAbout.test.tsx
@@ -56,7 +56,7 @@ describe("CompanionAbout", () => {
       </MemoryRouter>
     );
     await waitFor(() => expect(screen.getByText("demo_get_thing")).toBeInTheDocument());
-    expect(screen.getByText("demo_post_thing")).toBeInTheDocument();
+    expect(screen.getAllByText("demo_post_thing").length).toBeGreaterThanOrEqual(2);
     // write warning visible
     expect(screen.getByText(/writes to external systems/i)).toBeInTheDocument();
   });

--- a/tests/client/EntityDetail.test.tsx
+++ b/tests/client/EntityDetail.test.tsx
@@ -65,4 +65,32 @@ describe("EntityDetail", () => {
     expect(screen.getByText(/at foo/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
+
+  it("renders summary banner from artifact", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (url === "/api/companions") return new Response(JSON.stringify([
+        { name: "build", kind: "entity", displayName: "Build", icon: "🔨", description: "", contractVersion: "1", version: "0.1.0" },
+      ]), { status: 200 });
+      if (url.startsWith("/api/entities/build-abc")) return new Response(JSON.stringify({
+        id: "build-abc", companion: "build", status: "completed",
+        statusMessage: null, createdAt: "2026-04-25T00:00:00Z", updatedAt: "2026-04-25T00:00:01Z",
+        input: { mode: "new-companion", name: "x", kind: "entity", description: "" },
+        artifact: { summary: "Scaffolded x.", errors: ["minor warning"], filesCreated: [], filesModified: [], validatorPassed: true, smokeTestPassed: true },
+        errorMessage: null, errorStack: null, logs: [],
+      }), { status: 200 });
+      throw new Error("unexpected");
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/c/build/build-abc"]}>
+        <Routes>
+          <Route path="/c/:companion/:id" element={<EntityDetail />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText("Notes during this run")).toBeInTheDocument());
+    const banners = screen.getAllByText("Scaffolded x.");
+    expect(banners.length).toBeGreaterThan(0);
+    expect(screen.getByText("minor warning")).toBeInTheDocument();
+  });
 });

--- a/tests/client/EntityDetail.test.tsx
+++ b/tests/client/EntityDetail.test.tsx
@@ -89,8 +89,7 @@ describe("EntityDetail", () => {
       </MemoryRouter>
     );
     await waitFor(() => expect(screen.getByText("Notes during this run")).toBeInTheDocument());
-    const banners = screen.getAllByText("Scaffolded x.");
-    expect(banners.length).toBeGreaterThan(0);
+    expect(screen.getByText("Scaffolded x.")).toBeInTheDocument();
     expect(screen.getByText("minor warning")).toBeInTheDocument();
   });
 });

--- a/tests/client/NewEntity.test.tsx
+++ b/tests/client/NewEntity.test.tsx
@@ -10,6 +10,9 @@ beforeEach(() => {
         { name: "build", kind: "entity", displayName: "Build", icon: "🔨", description: "", contractVersion: "1", version: "0.1.0" },
       ]), { status: 200 });
     }
+    if (url === "/api/companions/build/preflight") {
+      return new Response(JSON.stringify({ ok: true, missingRequired: [], missingOptional: [] }), { status: 200 });
+    }
     if (url === "/api/entities" && init?.method === "POST") {
       return new Response(JSON.stringify({ id: "build-aaa111", companion: "build", status: "pending", input: JSON.parse(String(init.body)).input, logs: [], createdAt: "", updatedAt: "", statusMessage: null, artifact: null, errorMessage: null, errorStack: null }), { status: 201 });
     }
@@ -33,5 +36,35 @@ describe("NewEntity", () => {
     fireEvent.change(screen.getByLabelText(/^description$/i), { target: { value: "a test companion" } });
     fireEvent.click(screen.getByRole("button", { name: /scaffold companion/i }));
     await waitFor(() => expect(screen.getByText("detail-page")).toBeInTheDocument());
+  });
+
+  it("disables submit when preflight reports blocked status", async () => {
+    // Override fetch to return a blocked preflight for build
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/api/companions") {
+        return new Response(JSON.stringify([
+          { name: "build", kind: "entity", displayName: "Build", icon: "🔨", description: "", contractVersion: "1", version: "0.1.0", requiredEnv: ["BLOCKED_TOKEN"] },
+        ]), { status: 200 });
+      }
+      if (url === "/api/companions/build/preflight") {
+        return new Response(JSON.stringify({ ok: false, missingRequired: ["BLOCKED_TOKEN"], missingOptional: [] }), { status: 200 });
+      }
+      if (url === "/api/entities" && init?.method === "POST") {
+        return new Response(JSON.stringify({ id: "build-zzz999", companion: "build", status: "pending", input: {}, logs: [], createdAt: "", updatedAt: "", statusMessage: null, artifact: null, errorMessage: null, errorStack: null }), { status: 201 });
+      }
+      throw new Error(`unexpected ${url}`);
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/c/build/new"]}>
+        <Routes>
+          <Route path="/c/:companion/new" element={<NewEntity />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText(/BLOCKED_TOKEN/)).toBeInTheDocument());
+    // Submit button should be disabled
+    const button = screen.getByRole("button", { name: /scaffold companion/i });
+    expect(button).toBeDisabled();
   });
 });

--- a/tests/client/PreflightBanner.test.tsx
+++ b/tests/client/PreflightBanner.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import PreflightBanner from "../../src/client/components/PreflightBanner";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url === "/api/companions/blocked/preflight") {
+      return new Response(JSON.stringify({ ok: false, missingRequired: ["GITHUB_TOKEN"], missingOptional: [] }), { status: 200 });
+    }
+    if (url === "/api/companions/warn/preflight") {
+      return new Response(JSON.stringify({ ok: true, missingRequired: [], missingOptional: ["SLACK_TOKEN"] }), { status: 200 });
+    }
+    if (url === "/api/companions/ok/preflight") {
+      return new Response(JSON.stringify({ ok: true, missingRequired: [], missingOptional: [] }), { status: 200 });
+    }
+    throw new Error(`unexpected url: ${url}`);
+  }));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("PreflightBanner", () => {
+  it("renders blocking banner when missingRequired non-empty", async () => {
+    render(<PreflightBanner companion="blocked" />);
+    await waitFor(() => expect(screen.getByText(/GITHUB_TOKEN/)).toBeInTheDocument());
+    expect(screen.getByRole("alert")).toHaveTextContent(/required/i);
+  });
+
+  it("renders soft banner when only missingOptional", async () => {
+    render(<PreflightBanner companion="warn" />);
+    await waitFor(() => expect(screen.getByText(/SLACK_TOKEN/)).toBeInTheDocument());
+    expect(screen.getByRole("status")).toHaveTextContent(/optional/i);
+  });
+
+  it("renders nothing when all env is set", async () => {
+    const { container } = render(<PreflightBanner companion="ok" />);
+    await waitFor(() => expect(container.textContent).not.toContain("loading"));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("calls onStatus with blocked=true when required env missing", async () => {
+    const onStatus = vi.fn();
+    render(<PreflightBanner companion="blocked" onStatus={onStatus} />);
+    await waitFor(() => expect(onStatus).toHaveBeenCalledWith(expect.objectContaining({ blocked: true })));
+  });
+
+  it("calls onStatus with blocked=false when ok", async () => {
+    const onStatus = vi.fn();
+    render(<PreflightBanner companion="ok" onStatus={onStatus} />);
+    await waitFor(() => expect(onStatus).toHaveBeenCalledWith(expect.objectContaining({ blocked: false })));
+  });
+});

--- a/tests/client/usePreflight.test.tsx
+++ b/tests/client/usePreflight.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { usePreflight } from "../../src/client/hooks/usePreflight";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url === "/api/companions/x/preflight") {
+      return new Response(JSON.stringify({ ok: false, missingRequired: ["TOKEN"], missingOptional: [] }), { status: 200 });
+    }
+    if (url === "/api/companions/y/preflight") {
+      return new Response(JSON.stringify({ ok: true, missingRequired: [], missingOptional: [] }), { status: 200 });
+    }
+    if (url === "/api/companions/missing/preflight") {
+      return new Response(JSON.stringify({ error: "unknown" }), { status: 404 });
+    }
+    throw new Error(`unexpected url: ${url}`);
+  }));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("usePreflight", () => {
+  it("returns missingRequired when env is not set", async () => {
+    const { result } = renderHook(() => usePreflight("x"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.ok).toBe(false);
+    expect(result.current.missingRequired).toEqual(["TOKEN"]);
+  });
+
+  it("returns ok:true when no missing env", async () => {
+    const { result } = renderHook(() => usePreflight("y"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.ok).toBe(true);
+  });
+
+  it("treats 404 as ok:true (companion has no preflight requirement)", async () => {
+    const { result } = renderHook(() => usePreflight("missing"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.ok).toBe(true);
+  });
+});

--- a/tests/server/api-routes.test.ts
+++ b/tests/server/api-routes.test.ts
@@ -8,6 +8,8 @@ import { createEntityStore } from "../../src/server/entity-store";
 import { createRegistry } from "../../src/server/companion-registry";
 import { mountApiRoutes } from "../../src/server/api-routes";
 import type { Manifest } from "@shared/types";
+import { successResult } from "../../src/shared/types";
+import type { CompanionToolDefinition } from "../../src/shared/types";
 
 const manifest = (name: string): Manifest => ({
   name,
@@ -146,5 +148,55 @@ describe("preflight with required env", () => {
     const res = await request(a).get("/api/companions/env-test/preflight");
     expect(res.body.ok).toBe(true);
     expect(res.body.missingOptional).toEqual(["OPT_TOKEN"]);
+  });
+});
+
+describe("tools endpoint sideEffect", () => {
+  it("returns sideEffect on each tool descriptor", async () => {
+    const tmp2 = mkdtempSync(join(tmpdir(), "claudepanion-tools-"));
+    const store = createEntityStore(tmp2);
+    const toolReadOnly: CompanionToolDefinition = {
+      name: "tk_read",
+      description: "read",
+      schema: {},
+      sideEffect: "read",
+      async handler() { return successResult({}); },
+    };
+    const toolWrite: CompanionToolDefinition = {
+      name: "tk_write",
+      description: "write",
+      schema: {},
+      sideEffect: "write",
+      async handler() { return successResult({}); },
+    };
+    const m: Manifest = { ...manifest("tk"), kind: "tool" };
+    const registry = createRegistry([{ manifest: m, tools: [toolReadOnly, toolWrite] }]);
+    const app2 = express();
+    app2.use(express.json());
+    mountApiRoutes(app2, { store, registry });
+
+    const res = await request(app2).get("/api/tools/tk");
+    expect(res.status).toBe(200);
+    const tools = res.body.tools as Array<{ name: string; sideEffect?: string }>;
+    expect(tools.find((t) => t.name === "tk_read")?.sideEffect).toBe("read");
+    expect(tools.find((t) => t.name === "tk_write")?.sideEffect).toBe("write");
+  });
+
+  it("defaults sideEffect to 'read' when not specified", async () => {
+    const tmp2 = mkdtempSync(join(tmpdir(), "claudepanion-tools-"));
+    const store = createEntityStore(tmp2);
+    const toolNoFlag: CompanionToolDefinition = {
+      name: "tk_default",
+      description: "no flag",
+      schema: {},
+      async handler() { return successResult({}); },
+    };
+    const m: Manifest = { ...manifest("tk"), kind: "tool" };
+    const registry = createRegistry([{ manifest: m, tools: [toolNoFlag] }]);
+    const app2 = express();
+    app2.use(express.json());
+    mountApiRoutes(app2, { store, registry });
+    const res = await request(app2).get("/api/tools/tk");
+    expect(res.body.tools[0].sideEffect).toBe("read");
   });
 });

--- a/tests/server/api-routes.test.ts
+++ b/tests/server/api-routes.test.ts
@@ -88,4 +88,63 @@ describe("api routes", () => {
     expect(res.body.status).toBe("pending");
     expect(res.body.input.continuation).toBe("try again");
   });
+
+  it("GET /api/companions/:name/preflight returns ok:true for companion with no env declared", async () => {
+    const res = await request(app).get("/api/companions/x/preflight");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, missingRequired: [], missingOptional: [] });
+  });
+
+  it("GET /api/companions/:name/preflight 404s for unknown companion", async () => {
+    const res = await request(app).get("/api/companions/nope/preflight");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("preflight with required env", () => {
+  let envBackup: string | undefined;
+
+  beforeEach(() => {
+    envBackup = process.env.X_TOKEN;
+    delete process.env.X_TOKEN;
+  });
+
+  afterEach(() => {
+    if (envBackup !== undefined) process.env.X_TOKEN = envBackup;
+    else delete process.env.X_TOKEN;
+  });
+
+  function setupAppWithEnv(reqEnv: string[], optEnv: string[] = []) {
+    const tmp2 = mkdtempSync(join(tmpdir(), "claudepanion-pf-"));
+    const store = createEntityStore(tmp2);
+    const m: Manifest = { ...manifest("env-test"), requiredEnv: reqEnv, optionalEnv: optEnv };
+    const registry = createRegistry([{ manifest: m, tools: [] }]);
+    const app2 = express();
+    app2.use(express.json());
+    mountApiRoutes(app2, { store, registry });
+    return app2;
+  }
+
+  it("preflight reports missingRequired when env not set", async () => {
+    const a = setupAppWithEnv(["X_TOKEN"]);
+    const res = await request(a).get("/api/companions/env-test/preflight");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.missingRequired).toEqual(["X_TOKEN"]);
+  });
+
+  it("preflight returns ok:true when required env is set", async () => {
+    process.env.X_TOKEN = "value";
+    const a = setupAppWithEnv(["X_TOKEN"]);
+    const res = await request(a).get("/api/companions/env-test/preflight");
+    expect(res.body.ok).toBe(true);
+    expect(res.body.missingRequired).toEqual([]);
+  });
+
+  it("preflight reports missingOptional but ok:true when only optional is missing", async () => {
+    const a = setupAppWithEnv([], ["OPT_TOKEN"]);
+    const res = await request(a).get("/api/companions/env-test/preflight");
+    expect(res.body.ok).toBe(true);
+    expect(res.body.missingOptional).toEqual(["OPT_TOKEN"]);
+  });
 });

--- a/tests/server/reliability/validator.test.ts
+++ b/tests/server/reliability/validator.test.ts
@@ -83,4 +83,32 @@ describe("validateCompanion", () => {
     expect(r.ok).toBe(true);
     expect(r.issues.some((i) => i.code === "file.missing")).toBe(true);
   });
+
+  it("accepts manifest with requiredEnv and optionalEnv", () => {
+    const r = validateCompanion({
+      manifest: { ...baseManifest, requiredEnv: ["GITHUB_TOKEN"], optionalEnv: ["SLACK_TOKEN"] },
+      module: null,
+      companionDir: null,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.issues.filter((i) => i.fatal)).toEqual([]);
+  });
+
+  it("accepts manifest with requiredEnv that is empty array", () => {
+    const r = validateCompanion({
+      manifest: { ...baseManifest, requiredEnv: [] },
+      module: null,
+      companionDir: null,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("flags non-array requiredEnv as non-fatal", () => {
+    const r = validateCompanion({
+      manifest: { ...baseManifest, requiredEnv: "GITHUB_TOKEN" as any },
+      module: null,
+      companionDir: null,
+    });
+    expect(r.issues.some((i) => i.code === "manifest.requiredEnv.invalid")).toBe(true);
+  });
 });

--- a/tests/server/tool-meta.test.ts
+++ b/tests/server/tool-meta.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import type { CompanionToolDefinition } from "../../src/shared/types";
 import { successResult, errorResult } from "../../src/shared/types";
+import { configErrorResult, inputErrorResult, transientErrorResult } from "../../src/shared/types";
 
 describe("CompanionToolDefinition", () => {
   it("handler receives typed params and returns McpToolResult", async () => {
@@ -32,5 +33,30 @@ describe("CompanionToolDefinition", () => {
   it("successResult passes strings through as-is", () => {
     const r = successResult("hello");
     expect(r.content[0].text).toBe("hello");
+  });
+});
+
+describe("error class helpers", () => {
+  it("configErrorResult prefixes [config] and includes envVar", () => {
+    const r = configErrorResult("GITHUB_TOKEN");
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toBe("[config] GITHUB_TOKEN is not set");
+  });
+
+  it("configErrorResult includes hint when provided", () => {
+    const r = configErrorResult("GITHUB_TOKEN", "create a token with repo scope");
+    expect(r.content[0].text).toBe("[config] GITHUB_TOKEN is not set — create a token with repo scope");
+  });
+
+  it("inputErrorResult prefixes [input]", () => {
+    const r = inputErrorResult("PR not found");
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toBe("[input] PR not found");
+  });
+
+  it("transientErrorResult prefixes [transient]", () => {
+    const r = transientErrorResult("rate limited");
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toBe("[transient] rate limited");
   });
 });


### PR DESCRIPTION
## Summary

Foundation primitives for proxy companions, satisfying `docs/scaffold-spec.md`.

- **Manifest `requiredEnv` / `optionalEnv`** — companions declare their env-var dependencies
- **`GET /api/companions/:name/preflight`** — generic config-readiness check
- **`<PreflightBanner>`** — auto-renders blocking/soft banners on the New Entity form (and About page)
- **Error helpers** — `configErrorResult`, `inputErrorResult`, `transientErrorResult` standardize the four error classes
- **`CompanionToolDefinition.sideEffect`** — `"read" | "write"` flag drives About page warnings and skill permission flow
- **`BaseArtifact`** — common artifact fields (`summary?`, `errors?`) with `<BaseArtifactPanel>` doing generic rendering
- **`<CompanionAbout>` page** — default landing at `/c/:name`; List moves to `/c/:name/runs`
- **Skill template updates** — continuation detection, preflight check, four-class error handling, write-permission stanza
- **Build skill read-only bias** — when interpreting vague descriptions, default to read-only

Implements the plan at `docs/superpowers/plans/2026-04-25-scaffold-foundation.md` (17 tasks across 4 phases).

## Test plan

- [x] All vitest tests pass (`npm test -- --run`) — 133 tests
- [x] Typecheck passes (`npm run check`)
- [x] Build passes (`npm run build`)
- [x] Manual: server runs, `/api/companions/build/preflight` returns `{ok: true, ...}`
- [x] Manual: 404 for unknown companion preflight
- [ ] Manual: open http://localhost:3001 in browser, verify About page is default landing for build
- [ ] Manual: scaffold a build run, verify the new skill template steps work in Claude Code (smoke against the new continuation/preflight/error-class patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)