### PR TITLE
ui: Editorial · Cool facelift (build home, generic companion, install)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist
 # runtime data — contents gitignored, directory kept via .gitkeep
 data/*
 !data/.gitkeep
+
+# design handoff bundle — kept locally, not in git
+claudepanion.zip

--- a/companions/build/form.tsx
+++ b/companions/build/form.tsx
@@ -8,8 +8,22 @@ interface Props {
   onSubmit: (input: BuildInput) => void | Promise<void>;
 }
 
-const inputStyle = { padding: 8, border: "1px solid #cbd5e1", borderRadius: 6 };
-const labelStyle = { display: "flex", flexDirection: "column" as const, gap: 4, fontSize: 13 };
+const labelStyle = { display: "flex", flexDirection: "column" as const, gap: 6, fontSize: 13, fontWeight: 500 };
+const fieldStyle = {
+  width: "100%",
+  padding: "10px 12px",
+  border: "1px solid rgba(21, 24, 26, 0.15)",
+  borderRadius: 6,
+  background: "var(--bg)",
+  color: "var(--ink)",
+  fontSize: 14,
+  fontFamily: "inherit" as const,
+  transition: "border-color 0.15s ease, box-shadow 0.15s ease",
+};
+const monoFieldStyle = {
+  ...fieldStyle,
+  fontFamily: "var(--font-mono)" as const,
+};
 
 export default function BuildForm({ onSubmit }: Props) {
   const [params] = useSearchParams();
@@ -61,18 +75,45 @@ export default function BuildForm({ onSubmit }: Props) {
   };
 
   const tabStyle = (active: boolean) => ({
-    padding: "8px 14px",
-    border: `1px solid ${active ? "var(--accent, #0284c7)" : "#cbd5e1"}`,
-    background: active ? "var(--accent, #0284c7)" : "white",
-    color: active ? "white" : "#334155",
+    padding: "8px 18px",
     borderRadius: 6,
     cursor: "pointer" as const,
     fontSize: 13,
     fontWeight: 500,
+    border: `1px solid ${active ? "var(--ink)" : "rgba(21, 24, 26, 0.15)"}`,
+    background: active ? "var(--ink)" : "transparent",
+    color: active ? "var(--bg)" : "var(--muted)",
+    fontFamily: "inherit" as const,
+    transition: "background 0.15s ease, color 0.15s ease",
+  });
+
+  const kindCardStyle = (selected: boolean) => ({
+    flex: 1,
+    padding: "12px 14px",
+    textAlign: "left" as const,
+    cursor: "pointer" as const,
+    border: `1px solid ${selected ? "var(--sage)" : "rgba(21, 24, 26, 0.1)"}`,
+    borderRadius: 6,
+    background: selected ? "rgba(122, 135, 136, 0.1)" : "transparent",
+    fontFamily: "inherit" as const,
+    color: "inherit" as const,
   });
 
   return (
-    <form onSubmit={submit} style={{ maxWidth: 560, display: "flex", flexDirection: "column", gap: 16 }}>
+    <form onSubmit={submit} style={{ maxWidth: 640, display: "flex", flexDirection: "column", gap: 22 }}>
+      <h1 className="serif" style={{ fontSize: 48, lineHeight: 1.0, margin: 0 }}>
+        {mode === "new-companion" ? (
+          <>Build a new <span className="serif-italic" style={{ color: "var(--accent)" }}>companion</span>.</>
+        ) : (
+          <>Iterate on a <span className="serif-italic" style={{ color: "var(--accent)" }}>companion</span>.</>
+        )}
+      </h1>
+      <p style={{ fontSize: 15, color: "var(--muted)", margin: 0, maxWidth: 560, lineHeight: 1.55 }}>
+        {mode === "new-companion"
+          ? "Describe the tool you want. Name the external service, what data to fetch, and what the output should look like. Build interprets the description and scaffolds everything from there."
+          : "Pick a target companion and describe the change. Build edits files in place and bumps the version."}
+      </p>
+
       <div style={{ display: "flex", gap: 8 }}>
         <button type="button" style={tabStyle(mode === "new-companion")} onClick={() => setMode("new-companion")}>
           ✨ New companion
@@ -90,59 +131,84 @@ export default function BuildForm({ onSubmit }: Props) {
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="oncall-investigator"
-              style={inputStyle}
+              style={monoFieldStyle}
               pattern="^[a-z][a-z0-9-]*$"
             />
-            <span style={{ fontSize: 11, color: "#64748b" }}>lowercase, hyphens, starts with a letter</span>
+            <span style={{ fontSize: 11, color: "var(--muted)", fontWeight: 400 }}>lowercase · hyphens only · starts with a letter</span>
           </label>
-          <label style={labelStyle}>
-            Kind
-            <select value={kind} onChange={(e) => setKind(e.target.value as "entity" | "tool")} style={inputStyle}>
-              <option value="entity">entity — has lifecycle, form, artifacts</option>
-              <option value="tool">tool — MCP tools only, auto About page</option>
-            </select>
-          </label>
+
+          <div role="radiogroup" aria-label="Kind" style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <span style={{ fontSize: 13, fontWeight: 500 }}>Kind</span>
+            <div style={{ display: "flex", gap: 10 }}>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={kind === "entity"}
+                style={kindCardStyle(kind === "entity")}
+                onClick={() => setKind("entity")}
+              >
+                <div style={{ fontSize: 13, fontWeight: 600, color: "var(--ink)", marginBottom: 2 }}>entity</div>
+                <div style={{ fontSize: 11, color: "var(--muted)" }}>form, lifecycle, artifacts</div>
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={kind === "tool"}
+                style={kindCardStyle(kind === "tool")}
+                onClick={() => setKind("tool")}
+              >
+                <div style={{ fontSize: 13, fontWeight: 600, color: "var(--ink)", marginBottom: 2 }}>tool</div>
+                <div style={{ fontSize: 11, color: "var(--muted)" }}>MCP tools only, auto About page</div>
+              </button>
+            </div>
+          </div>
         </>
       ) : (
         <label style={labelStyle}>
           Target companion
-          <select value={target} onChange={(e) => setTarget(e.target.value)} style={inputStyle}>
+          <select value={target} onChange={(e) => setTarget(e.target.value)} style={fieldStyle}>
             <option value="">— select —</option>
             {targets.map((t) => (
               <option key={t.name} value={t.name}>
-                {t.icon} {t.displayName} <span>(v{t.version})</span>
+                {t.icon} {t.displayName} (v{t.version})
               </option>
             ))}
           </select>
         </label>
       )}
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
         <label style={labelStyle}>
           {mode === "new-companion" ? "Description" : "What should change?"}
           <textarea
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            rows={4}
+            rows={mode === "new-companion" ? 7 : 5}
             placeholder={
               mode === "new-companion"
                 ? "Describe the companion. Name the external service (GitHub, AWS, Linear, Slack, …), what data to fetch, and what the artifact should contain. Read-only by default — say explicitly if it should write back.\n\nExample: Review a GitHub PR — fetch the diff and existing comments, flag risky diffs, suggest review questions for the author. Read-only."
                 : "Add a dim() tool that sets brightness to a number between 0 and 1."
             }
-            style={{ ...inputStyle, resize: "vertical" as const }}
+            style={{ ...fieldStyle, resize: "vertical" as const, lineHeight: 1.6 }}
           />
         </label>
         {mode === "new-companion" && (
-          <span style={{ fontSize: 11, color: "#64748b", lineHeight: 1.4 }}>
-            Tip: companions get architectural value from authenticated proxy access to external systems. The form captures <strong>where</strong> to query (which repo / account / team / channel) — not "paste your text here."
+          <span style={{ fontSize: 11, color: "var(--muted)", lineHeight: 1.5 }}>
+            Tip: companions get architectural value from <strong style={{ color: "var(--ink)" }}>authenticated proxy access</strong> to external systems. The form captures <em>where</em> to query (which repo / account / team / channel) — not "paste your text here."
           </span>
         )}
       </div>
 
       {error && <div className="form-error" role="alert">{error}</div>}
-      <button className="btn" type="submit" style={{ alignSelf: "flex-start" }}>
-        {mode === "new-companion" ? "Build companion" : "Iterate"}
-      </button>
+
+      <div style={{ display: "flex", gap: 10, alignItems: "center", paddingTop: 4 }}>
+        <button className="btn" type="submit">
+          {mode === "new-companion" ? "Build companion →" : "Iterate →"}
+        </button>
+        <button type="button" className="btn-outline" onClick={() => window.history.back()}>
+          Cancel
+        </button>
+      </div>
     </form>
   );
 }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Localhost companion host for Claude Code — build small single-user web apps whose backend work is performed by Claude." />
     <meta name="robots" content="noindex" />
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%230ea5e9'/%3E%3C/svg%3E" />
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%233D6FB8'/%3E%3C/svg%3E" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
     <title>claudepanion</title>
   </head>
   <body>

--- a/src/client/components/BuildChips.tsx
+++ b/src/client/components/BuildChips.tsx
@@ -6,6 +6,18 @@ interface Props {
   heading?: string | null;
 }
 
+const SYSTEM_LABELS: Record<string, string> = {
+  "github-pr-reviewer": "GitHub API",
+  "cloudwatch-investigator": "AWS CloudWatch",
+  "linear-groomer": "Linear API",
+};
+
+const SHORT_DESCRIPTIONS: Record<string, string> = {
+  "github-pr-reviewer": "Flag risky diffs, suggest review questions. Read-only.",
+  "cloudwatch-investigator": "Query log groups, suggest root-cause hypotheses. Read-only.",
+  "linear-groomer": "Surface stale tickets, suggest priority changes. Read-only.",
+};
+
 export default function BuildChips({ heading = "Ideas to start from" }: Props) {
   const navigate = useNavigate();
 
@@ -14,38 +26,48 @@ export default function BuildChips({ heading = "Ideas to start from" }: Props) {
   };
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-      {heading && (
-        <div style={{ fontSize: 11, color: "#64748b", textTransform: "uppercase", letterSpacing: "0.06em", fontWeight: 500 }}>
-          {heading}
-        </div>
-      )}
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      {heading && <div className="eyebrow">{heading}</div>}
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-        {buildExamples.map((ex, i) => (
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 14 }}>
+        {buildExamples.map((ex) => (
           <button
             key={ex.slug}
             type="button"
             data-testid="chip"
             onClick={() => openExample(ex)}
+            className="card-bordered"
             style={{
-              padding: "12px 14px",
-              border: "1px solid #cbd5e1",
-              borderRadius: 8,
-              background: "#fff",
-              display: "flex",
-              gap: 12,
-              alignItems: "flex-start",
-              cursor: "pointer",
+              background: "var(--bg)",
               textAlign: "left",
-              gridColumn: i === buildExamples.length - 1 && buildExamples.length % 2 === 1 ? "span 2" : undefined,
+              cursor: "pointer",
+              font: "inherit",
+              color: "inherit",
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+              minHeight: 200,
             }}
           >
-            <span style={{ fontSize: 20, flexShrink: 0 }} aria-hidden="true">{ex.icon}</span>
-            <span>
-              <span style={{ display: "block", fontWeight: 600, fontSize: 13, color: "#1e293b" }}>{ex.displayName}</span>
-              <span style={{ display: "block", fontSize: 12, color: "#475569", marginTop: 2, lineHeight: 1.4 }}>{ex.description}</span>
-            </span>
+            <div style={{ fontSize: 26 }} aria-hidden="true">{ex.icon}</div>
+            <div className="serif" style={{ fontSize: 22, lineHeight: 1.15 }}>{ex.displayName}</div>
+            <div style={{ fontSize: 13, color: "var(--muted)", lineHeight: 1.5, flex: 1 }}>
+              {SHORT_DESCRIPTIONS[ex.slug] ?? ex.description}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                paddingTop: 12,
+                borderTop: "1px dashed rgba(21, 24, 26, 0.08)",
+              }}
+            >
+              <span className="mono" style={{ fontSize: 10, color: "var(--muted)", letterSpacing: "0.05em" }}>
+                → {SYSTEM_LABELS[ex.slug] ?? ""}
+              </span>
+              <span className="serif-italic" style={{ fontSize: 18, color: "var(--muted)" }}>→</span>
+            </div>
           </button>
         ))}
       </div>

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -11,44 +11,53 @@ export default function Sidebar() {
     <aside className="app-sidebar">
       <div className="sidebar-logo">
         <div className="sidebar-logo-icon" />
-        <span>claudepanion</span>
+        <span className="sidebar-logo-name">claudepanion</span>
       </div>
+      <div className="sidebar-logo-sub">localhost:3001</div>
+
       <div className="sidebar-section-label">Core</div>
       {build ? (
         <NavLink to={`/c/${build.name}`} className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-          <span>{build.icon}</span>
+          <span className="sidebar-link-icon">{build.icon}</span>
           <span>{build.displayName}</span>
         </NavLink>
       ) : (
-        <div className="sidebar-link" aria-disabled>🔨 Build <span style={{ marginLeft: "auto", fontSize: 10, color: "#64748b" }}>soon</span></div>
+        <div className="sidebar-link sidebar-link-muted" aria-disabled>
+          <span className="sidebar-link-icon">🔨</span>
+          <span>Build</span>
+        </div>
       )}
-      {entities.length > 0 && (
-        <>
-          <div className="sidebar-section-label">Companions</div>
-          {entities.map((c) => (
-            <NavLink key={c.name} to={`/c/${c.name}`} className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-              <span>{c.icon}</span>
-              <span>{c.displayName}</span>
-            </NavLink>
-          ))}
-        </>
+
+      <div className="sidebar-section-label">Companions</div>
+      {entities.length > 0 ? (
+        entities.map((c) => (
+          <NavLink key={c.name} to={`/c/${c.name}`} className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
+            <span className="sidebar-link-icon">{c.icon}</span>
+            <span>{c.displayName}</span>
+          </NavLink>
+        ))
+      ) : (
+        <div className="sidebar-section-empty">Build something to fill this section.</div>
       )}
-      {tools.length > 0 && (
-        <>
-          <div className="sidebar-section-label">Tools</div>
-          {tools.map((c) => (
-            <NavLink key={c.name} to={`/c/${c.name}`} className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-              <span>{c.icon}</span>
-              <span>{c.displayName}</span>
-            </NavLink>
-          ))}
-        </>
+
+      <div className="sidebar-section-label">Tools</div>
+      {tools.length > 0 ? (
+        tools.map((c) => (
+          <NavLink key={c.name} to={`/c/${c.name}`} className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
+            <span className="sidebar-link-icon">{c.icon}</span>
+            <span>{c.displayName}</span>
+          </NavLink>
+        ))
+      ) : (
+        <div className="sidebar-section-empty">—</div>
       )}
+
       <div className="sidebar-footer">
-        <NavLink to="/install" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-          <span>+</span>
+        <NavLink to="/install" className={({ isActive }) => `sidebar-link sidebar-link-muted${isActive ? " active" : ""}`}>
+          <span className="sidebar-link-icon">+</span>
           <span>Install companion</span>
         </NavLink>
+        <div className="sidebar-footnote">Independent open-source project. Not affiliated with Anthropic.</div>
       </div>
     </aside>
   );

--- a/src/client/icons/Sketch.tsx
+++ b/src/client/icons/Sketch.tsx
@@ -1,0 +1,64 @@
+interface SketchProps {
+  size?: number;
+  color?: string;
+}
+
+const base = (size: number, color: string) => ({
+  width: size,
+  height: size,
+  viewBox: "0 0 48 48",
+  fill: "none",
+  stroke: color,
+  strokeWidth: 1.4,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+});
+
+export const Companion = ({ size = 48, color = "currentColor" }: SketchProps) => (
+  <svg {...base(size, color)}>
+    <path d="M10 14 Q10 10 14 10 L34 10 Q38 10 38 14 L38 30 Q38 34 34 34 L26 34 L22 39 L22 34 L14 34 Q10 34 10 30 Z" />
+    <circle cx="20" cy="22" r="1.5" fill={color} />
+    <circle cx="28" cy="22" r="1.5" fill={color} />
+    <path d="M20 27 Q24 29 28 27" />
+  </svg>
+);
+
+export const Form = ({ size = 48, color = "currentColor" }: SketchProps) => (
+  <svg {...base(size, color)}>
+    <rect x="9" y="8" width="30" height="34" rx="2" />
+    <path d="M14 16 L34 16 M14 22 L28 22 M14 28 L34 28 M14 34 L24 34" />
+    <rect x="29" y="32" width="8" height="6" rx="1" fill={color} fillOpacity="0.15" />
+  </svg>
+);
+
+export const Slash = ({ size = 48, color = "currentColor" }: SketchProps) => (
+  <svg {...base(size, color)}>
+    <rect x="6" y="14" width="36" height="22" rx="2" />
+    <path d="M14 22 L18 28 L14 34" />
+    <path d="M22 34 L34 34" />
+  </svg>
+);
+
+export const Wrench = ({ size = 48, color = "currentColor" }: SketchProps) => (
+  <svg {...base(size, color)}>
+    <path d="M30 8 a8 8 0 0 1 8 8 a8 8 0 0 1 -10 7.7 L12 40 a3 3 0 0 1 -4 -4 L24.3 20 A8 8 0 0 1 30 8 Z" />
+    <circle cx="32" cy="16" r="2" fill={color} />
+  </svg>
+);
+
+export const Doc = ({ size = 48, color = "currentColor" }: SketchProps) => (
+  <svg {...base(size, color)}>
+    <path d="M12 6 L30 6 L38 14 L38 42 L12 42 Z" />
+    <path d="M30 6 L30 14 L38 14" />
+    <path d="M17 22 L33 22 M17 28 L33 28 M17 34 L27 34" />
+  </svg>
+);
+
+export const Plant = ({ size = 48, color = "currentColor" }: SketchProps) => (
+  <svg {...base(size, color)}>
+    <path d="M24 40 L24 22" />
+    <path d="M24 28 Q14 24 14 14 Q22 16 24 24" />
+    <path d="M24 24 Q34 20 34 12 Q26 14 24 22" />
+    <path d="M16 40 L32 40 L30 44 L18 44 Z" />
+  </svg>
+);

--- a/src/client/pages/BuildHome.tsx
+++ b/src/client/pages/BuildHome.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import type { Entity, Manifest } from "@shared/types";
+import { fetchCompanions, fetchEntities } from "../api";
+import StatusPill from "../components/StatusPill";
+import BuildChips from "../components/BuildChips";
+import PreflightBanner from "../components/PreflightBanner";
+
+export default function BuildHome() {
+  const navigate = useNavigate();
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [entities, setEntities] = useState<Entity[]>([]);
+
+  useEffect(() => {
+    void fetchCompanions().then((all) => setManifest(all.find((m) => m.name === "build") ?? null));
+    void fetchEntities("build").then(setEntities);
+  }, []);
+
+  if (!manifest) return <div style={{ color: "var(--muted)" }}>Loading…</div>;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 36 }}>
+      {/* Top strip */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div className="mono" style={{ fontSize: 11, color: "var(--muted)", display: "flex", gap: 8 }}>
+          <span>~/</span>
+          <span style={{ color: "var(--ink)" }}>build</span>
+        </div>
+        <span className="eyebrow-pill">v{manifest.version} · {typeof window !== "undefined" ? window.location.host : "localhost"}</span>
+      </div>
+
+      <PreflightBanner companion="build" />
+
+      {/* Welcome hero */}
+      <section
+        className="card"
+        style={{
+          padding: "28px 32px",
+          display: "grid",
+          gridTemplateColumns: "1fr auto",
+          gap: 32,
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <div style={{ display: "flex", gap: 8, marginBottom: 14 }}>
+            <span className="eyebrow-pill eyebrow-pill-accent">The Build companion · core</span>
+          </div>
+          <h1 className="serif" style={{ fontSize: 52, lineHeight: 1.0, margin: "0 0 14px" }}>
+            <span className="serif-italic">Hi, I'm Build</span> — your first
+            <br />
+            companion.
+          </h1>
+          <p style={{ fontSize: 16, lineHeight: 1.55, color: "var(--muted)", margin: 0, maxWidth: 600 }}>
+            I scaffold new companions from a plain-English description. Everything else you add to the sidebar came from me. Try one of the ideas below, or describe your own.
+          </p>
+        </div>
+        <div
+          style={{
+            width: 160,
+            height: 160,
+            background: "var(--bg)",
+            border: "1px dashed rgba(21, 24, 26, 0.2)",
+            borderRadius: 12,
+            display: "grid",
+            placeItems: "center",
+            flexShrink: 0,
+            fontSize: 64,
+            lineHeight: 1,
+          }}
+          aria-hidden="true"
+        >
+          {manifest.icon}
+        </div>
+      </section>
+
+      {/* Two-mode cards */}
+      <section>
+        <div className="eyebrow" style={{ marginBottom: 12 }}>Two ways to start</div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+          <ModeCard
+            label="✨ NEW COMPANION"
+            title="Scaffold from scratch"
+            description="Pick a kind (entity / tool), describe what it should do — Build authors the manifest, types, form, pages, MCP tools, and the skill."
+            onClick={() => navigate("/c/build/new")}
+          />
+          <ModeCard
+            label="⟳ ITERATE ON EXISTING"
+            title="Evolve a companion"
+            description="Pick a target companion, describe the change — Build edits files in place and bumps the version."
+            onClick={() => navigate("/c/build/new?mode=iterate")}
+          />
+        </div>
+      </section>
+
+      {/* Chips */}
+      <section>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 14 }}>
+          <h2 className="eyebrow" style={{ margin: 0 }}>Ideas to start from · prefills the form</h2>
+          <Link to="/c/build/new" style={{ fontSize: 12, color: "var(--accent)", textDecoration: "none" }}>
+            or describe your own →
+          </Link>
+        </div>
+        <BuildChips heading={null} />
+      </section>
+
+      {/* Past builds */}
+      <PastBuilds entities={entities} />
+    </div>
+  );
+}
+
+function ModeCard({
+  label,
+  title,
+  description,
+  onClick,
+}: {
+  label: string;
+  title: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="card-bordered"
+      style={{
+        background: "var(--paper)",
+        textAlign: "left",
+        cursor: "pointer",
+        font: "inherit",
+        color: "inherit",
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+    >
+      <div className="mono" style={{ fontSize: 11, color: "var(--accent)", letterSpacing: "0.08em" }}>{label}</div>
+      <div className="serif" style={{ fontSize: 24, lineHeight: 1.15 }}>{title}</div>
+      <div style={{ fontSize: 13, color: "var(--muted)", lineHeight: 1.5 }}>{description}</div>
+    </button>
+  );
+}
+
+function PastBuilds({ entities }: { entities: Entity[] }) {
+  const visible = entities.slice(0, 8);
+  return (
+    <section>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 14 }}>
+        <h2 className="eyebrow" style={{ margin: 0 }}>Past builds · {entities.length} entit{entities.length === 1 ? "y" : "ies"}</h2>
+        {entities.length > visible.length && (
+          <Link to="/c/build/runs" style={{ fontSize: 12, color: "var(--muted)", textDecoration: "none" }}>show all →</Link>
+        )}
+      </div>
+
+      {entities.length === 0 ? (
+        <div style={{
+          padding: "36px 24px",
+          textAlign: "center",
+          color: "var(--muted)",
+          background: "var(--paper)",
+          border: "1px solid rgba(21, 24, 26, 0.08)",
+          borderRadius: 8,
+          fontStyle: "italic",
+          fontFamily: "var(--font-serif)",
+          fontSize: 18,
+        }}>
+          No builds yet. The first one always feels like magic.
+        </div>
+      ) : (
+        <div style={{ background: "var(--paper)", border: "1px solid rgba(21, 24, 26, 0.08)", borderRadius: 8, overflow: "hidden" }}>
+          <div className="mono" style={{
+            display: "grid",
+            gridTemplateColumns: "120px 80px 1fr 110px 90px 20px",
+            padding: "10px 18px",
+            fontSize: 10,
+            color: "var(--muted)",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            borderBottom: "1px solid rgba(21, 24, 26, 0.08)",
+            gap: 14,
+          }}>
+            <span>id</span>
+            <span>mode</span>
+            <span>target · description</span>
+            <span>status</span>
+            <span style={{ textAlign: "right" }}>updated</span>
+            <span></span>
+          </div>
+          {visible.map((e, i) => (
+            <BuildRow key={e.id} entity={e} isLast={i === visible.length - 1} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function BuildRow({ entity, isLast }: { entity: Entity; isLast: boolean }) {
+  const input = entity.input as { mode?: string; name?: string; target?: string; description?: string };
+  const mode = input.mode === "iterate-companion" ? "iterate" : "new";
+  const target = input.name ?? input.target ?? "—";
+  const description = input.description ?? "";
+  return (
+    <Link
+      to={`/c/build/${entity.id}`}
+      className="entity-list-row"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "120px 80px 1fr 110px 90px 20px",
+        padding: "14px 18px",
+        alignItems: "center",
+        gap: 14,
+        borderTop: 0,
+        borderBottom: isLast ? 0 : "1px dashed rgba(21, 24, 26, 0.08)",
+        fontSize: 13,
+      }}
+    >
+      <span className="mono" style={{ fontSize: 11, color: "var(--muted)" }}>{entity.id}</span>
+      <span style={{
+        fontSize: 11,
+        padding: "2px 8px",
+        borderRadius: 999,
+        alignSelf: "center",
+        justifySelf: "start",
+        background: mode === "new" ? "rgba(109, 40, 217, 0.12)" : "rgba(30, 64, 175, 0.12)",
+        color: mode === "new" ? "#6d28d9" : "#1e40af",
+      }}>
+        {mode === "new" ? "✨ new" : "⟳ iterate"}
+      </span>
+      <div style={{ minWidth: 0 }}>
+        <div className="serif-italic" style={{ fontSize: 17 }}>{target}</div>
+        <div style={{
+          fontSize: 12,
+          color: "var(--muted)",
+          marginTop: 2,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}>
+          {description}
+        </div>
+      </div>
+      <StatusPill status={entity.status} />
+      <span style={{ fontSize: 11, color: "var(--muted)", textAlign: "right" }}>{timeAgo(entity.updatedAt)}</span>
+      <span className="serif-italic" style={{ fontSize: 18, color: "var(--muted)", textAlign: "right" }}>›</span>
+    </Link>
+  );
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
+}

--- a/src/client/pages/CompanionAbout.tsx
+++ b/src/client/pages/CompanionAbout.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import type { Manifest } from "@shared/types";
+import type { Entity, Manifest } from "@shared/types";
 import Breadcrumb from "../components/Breadcrumb";
 import PreflightBanner from "../components/PreflightBanner";
+import StatusPill from "../components/StatusPill";
 import BuildChips from "../components/BuildChips";
-import { fetchCompanions, deleteCompanion } from "../api";
+import { fetchCompanions, fetchEntities, deleteCompanion } from "../api";
 
 interface ToolDescriptor {
   name: string;
@@ -24,25 +25,9 @@ export default function CompanionAbout() {
   const navigate = useNavigate();
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [payload, setPayload] = useState<AboutPayload | null>(null);
+  const [entities, setEntities] = useState<Entity[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
-
-  const onRemove = async () => {
-    if (!manifest) return;
-    const ok = window.confirm(
-      `Remove "${manifest.displayName}"? This deletes companions/${manifest.name}/, its skill, and any saved entities. This cannot be undone.`
-    );
-    if (!ok) return;
-    setDeleting(true);
-    try {
-      const { rebuildHint } = await deleteCompanion(manifest.name);
-      if (rebuildHint) window.alert(`Removed. ${rebuildHint}`);
-      navigate("/");
-    } catch (e) {
-      setError((e as Error).message);
-      setDeleting(false);
-    }
-  };
 
   useEffect(() => {
     let cancelled = false;
@@ -64,7 +49,6 @@ export default function CompanionAbout() {
       try {
         const r = await fetch(`/api/tools/${encodeURIComponent(companion)}`);
         if (r.status === 400 || r.status === 404) {
-          // Entity-kind doesn't have /api/tools; build payload from manifest only.
           if (!cancelled) setPayload({ manifest, tools: [] });
           return;
         }
@@ -77,36 +61,96 @@ export default function CompanionAbout() {
     return () => { cancelled = true; };
   }, [companion, manifest]);
 
+  useEffect(() => {
+    if (!manifest || manifest.kind !== "entity") return;
+    let cancelled = false;
+    void fetchEntities(companion).then((es) => { if (!cancelled) setEntities(es); });
+    return () => { cancelled = true; };
+  }, [companion, manifest]);
+
+  const onRemove = async () => {
+    if (!manifest) return;
+    const ok = window.confirm(
+      `Remove "${manifest.displayName}"? This deletes companions/${manifest.name}/, its skill, and any saved entities. This cannot be undone.`
+    );
+    if (!ok) return;
+    setDeleting(true);
+    try {
+      const { rebuildHint } = await deleteCompanion(manifest.name);
+      if (rebuildHint) window.alert(`Removed. ${rebuildHint}`);
+      navigate("/");
+    } catch (e) {
+      setError((e as Error).message);
+      setDeleting(false);
+    }
+  };
+
   if (error) return <div style={{ color: "#dc2626" }}>Failed to load: {error}</div>;
   if (!manifest || !payload) return <div style={{ color: "var(--muted)" }}>Loading…</div>;
 
   const writeTools = payload.tools.filter((t) => t.sideEffect === "write");
   const readTools = payload.tools.filter((t) => t.sideEffect === "read");
   const hasWrites = writeTools.length > 0;
+  const visibleEntities = entities.slice(0, 8);
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+    <div style={{ display: "flex", flexDirection: "column", gap: 28 }}>
       <Breadcrumb manifest={manifest} />
-      <header style={{ display: "flex", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
-        <span style={{ fontSize: 40 }} aria-hidden="true">{manifest.icon}</span>
-        <div style={{ flex: 1, minWidth: 220 }}>
-          <h1 style={{ margin: 0 }}>{manifest.displayName}</h1>
-          <div style={{ fontSize: 12, color: "var(--muted)", marginTop: 4 }}>
-            claudepanion-{manifest.name} · v{manifest.version}
-            {hasWrites
-              ? <span className="badge badge-write" style={{ marginLeft: 8 }}>writes</span>
-              : payload.tools.length > 0 && <span className="badge badge-read" style={{ marginLeft: 8 }}>read-only</span>}
+
+      {/* Companion header */}
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 20, flexWrap: "wrap" }}>
+        <div style={{ display: "flex", gap: 18, alignItems: "flex-start", minWidth: 0, flex: 1 }}>
+          <div
+            aria-hidden="true"
+            style={{
+              width: 56,
+              height: 56,
+              background: "var(--soft)",
+              border: "1px solid rgba(21, 24, 26, 0.08)",
+              borderRadius: 10,
+              display: "grid",
+              placeItems: "center",
+              fontSize: 26,
+              flexShrink: 0,
+            }}
+          >
+            {manifest.icon}
           </div>
-          <p style={{ marginTop: 8, marginBottom: 0 }}>{manifest.description}</p>
+          <div style={{ minWidth: 0 }}>
+            <h1 className="serif" style={{ fontSize: 40, lineHeight: 1.05, margin: "0 0 6px" }}>
+              {manifest.displayName}
+            </h1>
+            <p style={{ margin: "0 0 8px", fontSize: 14, color: "var(--muted)", lineHeight: 1.5, maxWidth: 600 }}>
+              {manifest.description}
+            </p>
+            <div style={{ display: "flex", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+              <span className="mono" style={{ fontSize: 10, color: "var(--muted)", background: "var(--soft)", padding: "3px 8px", borderRadius: 4 }}>
+                v{manifest.version}
+              </span>
+              <span className="mono" style={{ fontSize: 10, color: "var(--muted)" }}>
+                {manifest.kind} · {entities.length} {entities.length === 1 ? "run" : "runs"}
+              </span>
+              {hasWrites
+                ? <span className="badge badge-write">writes</span>
+                : payload.tools.length > 0 && <span className="badge badge-read">read-only</span>}
+            </div>
+          </div>
         </div>
+
         {manifest.kind === "entity" && (
-          <Link to={`/c/${manifest.name}/new`} className="btn" style={{ whiteSpace: "nowrap" }}>
-            {manifest.actionLabels?.newEntity ?? "Start a new run"}
-          </Link>
+          <div style={{ display: "flex", gap: 10, flexShrink: 0, alignItems: "center" }}>
+            <button
+              type="button"
+              className="btn-outline"
+              onClick={() => navigate(`/c/build/new?mode=iterate&target=${encodeURIComponent(companion)}`)}
+            >
+              🔨 Iterate with Build
+            </button>
+            <button type="button" className="btn" onClick={() => navigate(`/c/${companion}/new`)}>
+              {manifest.actionLabels?.newEntity ?? "+ New run"}
+            </button>
+          </div>
         )}
-        <Link to={`/c/${manifest.name}/runs`} className="btn-outline" style={{ whiteSpace: "nowrap" }}>
-          {manifest.actionLabels?.listEntities ?? "View runs"}
-        </Link>
       </header>
 
       <PreflightBanner companion={companion} />
@@ -127,12 +171,30 @@ export default function CompanionAbout() {
         </div>
       )}
 
+      {/* Runs / empty state — entity-kind only */}
+      {manifest.kind === "entity" && (
+        entities.length === 0 ? (
+          <EmptyRuns
+            manifest={manifest}
+            onNew={() => navigate(`/c/${companion}/new`)}
+            onIterate={() => navigate(`/c/build/new?mode=iterate&target=${encodeURIComponent(companion)}`)}
+          />
+        ) : (
+          <RunsList
+            companion={companion}
+            entities={visibleEntities}
+            total={entities.length}
+          />
+        )
+      )}
+
+      {/* MCP tools (kept — useful informational section) */}
       {payload.tools.length > 0 && (
         <section>
-          <h2 style={{ marginTop: 0, marginBottom: 12, fontSize: 18 }}>MCP tools</h2>
+          <h2 className="eyebrow" style={{ margin: "0 0 12px" }}>MCP tools</h2>
           <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
             {[...readTools, ...writeTools].map((t) => (
-              <div key={t.name} style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 12 }}>
+              <div key={t.name} style={{ border: "1px solid rgba(21, 24, 26, 0.08)", borderRadius: 8, padding: 12, background: "var(--paper)" }}>
                 <code style={{ fontSize: 13, fontWeight: 600 }}>{t.name}</code>
                 {t.sideEffect === "write" && <span className="badge badge-write" style={{ marginLeft: 8 }}>write</span>}
                 {t.description && <div style={{ fontSize: 13, color: "var(--muted)", marginTop: 4 }}>{t.description}</div>}
@@ -144,10 +206,11 @@ export default function CompanionAbout() {
 
       {manifest.name === "build" && <BuildChips />}
 
+      {/* Danger zone — non-build only */}
       {manifest.name !== "build" && (
-        <section style={{ borderTop: "1px solid #e2e8f0", paddingTop: 16, marginTop: 8 }}>
-          <h2 style={{ marginTop: 0, marginBottom: 8, fontSize: 16 }}>Danger zone</h2>
-          <div style={{ fontSize: 13, color: "var(--muted)", marginBottom: 12 }}>
+        <section style={{ borderTop: "1px solid rgba(21, 24, 26, 0.08)", paddingTop: 16, marginTop: 8 }}>
+          <h2 className="eyebrow" style={{ margin: "0 0 8px" }}>Danger zone</h2>
+          <div style={{ fontSize: 13, color: "var(--muted)", marginBottom: 12, lineHeight: 1.55 }}>
             Deletes <code>companions/{manifest.name}/</code>, its skill, and saved entities. A rebuild is needed to fully remove it from the client bundle.
           </div>
           <button
@@ -155,13 +218,16 @@ export default function CompanionAbout() {
             onClick={onRemove}
             disabled={deleting}
             style={{
-              padding: "8px 14px",
-              border: "1px solid #dc2626",
-              color: "#dc2626",
-              background: "white",
-              borderRadius: 6,
+              padding: "8px 16px",
+              border: "1px solid #C0463D",
+              color: "#C0463D",
+              background: "transparent",
+              borderRadius: 999,
               cursor: deleting ? "not-allowed" : "pointer",
               opacity: deleting ? 0.5 : 1,
+              fontFamily: "inherit",
+              fontSize: 13,
+              fontWeight: 500,
             }}
           >
             {deleting ? "Removing…" : "Remove companion"}
@@ -170,4 +236,130 @@ export default function CompanionAbout() {
       )}
     </div>
   );
+}
+
+function EmptyRuns({
+  manifest,
+  onNew,
+  onIterate,
+}: {
+  manifest: Manifest;
+  onNew: () => void;
+  onIterate: () => void;
+}) {
+  return (
+    <div
+      style={{
+        textAlign: "center",
+        padding: "60px 32px",
+        border: "1px dashed rgba(21, 24, 26, 0.15)",
+        borderRadius: 10,
+      }}
+    >
+      <div style={{ fontSize: 40, marginBottom: 14 }} aria-hidden="true">{manifest.icon}</div>
+      <h2 className="serif" style={{ fontSize: 32, margin: "0 0 10px" }}>No runs yet.</h2>
+      <p style={{ fontSize: 14, color: "var(--muted)", margin: "0 auto 24px", lineHeight: 1.55, maxWidth: 420 }}>
+        Start a new run and fill out the form. Claude Code picks it up when you paste the slash command.
+      </p>
+      <div style={{ display: "flex", gap: 10, justifyContent: "center", flexWrap: "wrap" }}>
+        <button type="button" className="btn" onClick={onNew}>
+          {manifest.actionLabels?.newEntity ?? "+ New run"}
+        </button>
+        <button type="button" className="btn-outline" onClick={onIterate}>
+          🔨 Iterate with Build
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RunsList({
+  companion,
+  entities,
+  total,
+}: {
+  companion: string;
+  entities: Entity[];
+  total: number;
+}) {
+  return (
+    <section>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 12 }}>
+        <h2 className="eyebrow" style={{ margin: 0 }}>
+          Past runs · {total} {total === 1 ? "run" : "runs"}
+        </h2>
+        {total > entities.length && (
+          <Link to={`/c/${companion}/runs`} style={{ fontSize: 12, color: "var(--muted)", textDecoration: "none" }}>show all →</Link>
+        )}
+      </div>
+      <div style={{ background: "var(--paper)", border: "1px solid rgba(21, 24, 26, 0.08)", borderRadius: 8, overflow: "hidden" }}>
+        <div className="mono" style={{
+          display: "grid",
+          gridTemplateColumns: "110px 1fr 130px 90px",
+          padding: "10px 18px",
+          fontSize: 10,
+          color: "var(--muted)",
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          borderBottom: "1px solid rgba(21, 24, 26, 0.08)",
+          gap: 14,
+        }}>
+          <span>status</span>
+          <span>description</span>
+          <span style={{ textAlign: "right" }}>id</span>
+          <span style={{ textAlign: "right" }}>updated</span>
+        </div>
+        {entities.map((e, i) => (
+          <Link
+            key={e.id}
+            to={`/c/${companion}/${e.id}`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "110px 1fr 130px 90px",
+              padding: "14px 18px",
+              alignItems: "center",
+              gap: 14,
+              borderBottom: i < entities.length - 1 ? "1px dashed rgba(21, 24, 26, 0.08)" : 0,
+              textDecoration: "none",
+              color: "var(--ink)",
+              fontSize: 14,
+              transition: "background 0.15s ease",
+            }}
+            onMouseEnter={(ev) => (ev.currentTarget.style.background = "var(--bg)")}
+            onMouseLeave={(ev) => (ev.currentTarget.style.background = "transparent")}
+          >
+            <StatusPill status={e.status} />
+            <span style={{
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color: e.status === "error" ? "var(--muted)" : "var(--ink)",
+            }}>
+              {entityDescription(e)}
+            </span>
+            <span className="mono" style={{ fontSize: 11, color: "var(--muted)", textAlign: "right" }}>{e.id}</span>
+            <span style={{ fontSize: 12, color: "var(--muted)", textAlign: "right" }}>{timeAgo(e.updatedAt)}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function entityDescription(e: Entity): string {
+  const input = e.input as Record<string, unknown>;
+  const candidates = ["title", "description", "name", "target", "summary"];
+  for (const key of candidates) {
+    const v = input?.[key];
+    if (typeof v === "string" && v.trim()) return v;
+  }
+  return JSON.stringify(input).slice(0, 120);
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
 }

--- a/src/client/pages/CompanionRoute.tsx
+++ b/src/client/pages/CompanionRoute.tsx
@@ -1,5 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useCompanions } from "../hooks/useCompanions";
+import BuildHome from "./BuildHome";
 import CompanionAbout from "./CompanionAbout";
 import ToolAbout from "./ToolAbout";
 
@@ -9,5 +10,6 @@ export default function CompanionRoute() {
   if (loading) return <div style={{ color: "var(--muted)" }}>Loading…</div>;
   const manifest = companions.find((c) => c.name === companion);
   if (!manifest) return <div style={{ color: "#dc2626" }}>Unknown companion: {companion}</div>;
+  if (manifest.name === "build") return <BuildHome />;
   return manifest.kind === "tool" ? <ToolAbout /> : <CompanionAbout />;
 }

--- a/src/client/pages/EntityDetail.tsx
+++ b/src/client/pages/EntityDetail.tsx
@@ -32,9 +32,11 @@ export default function EntityDetail() {
       {manifest && <Breadcrumb manifest={manifest} trailing={entity.id} />}
       <div className="page-title">
         <div>
-          <h1>{describeEntity(entity)}</h1>
-          <div style={{ marginTop: 4, fontSize: 12, color: "var(--muted)" }}>
-            {subtitle(entity)} · ID <code>{entity.id}</code>
+          <h1 className="serif" style={{ fontSize: 40, lineHeight: 1.05, letterSpacing: "-0.01em" }}>
+            {describeEntity(entity)}
+          </h1>
+          <div className="mono" style={{ marginTop: 6, fontSize: 11, color: "var(--muted)" }}>
+            {subtitle(entity)} · ID {entity.id}
           </div>
         </div>
         <StatusPill status={entity.status} />
@@ -105,9 +107,9 @@ function RunningBody({ entity, onRerun }: { entity: Entity; onRerun: () => void 
     <>
       {stale && <StaleBadge updatedAt={entity.updatedAt} onRerun={onRerun} />}
       {entity.statusMessage && <StatusBar message={entity.statusMessage} updatedAt={entity.updatedAt} />}
-      <div className="panel" style={{ padding: "10px 14px", display: "flex", gap: 12, fontSize: 13, background: "#f8fafc" }}>
+      <div className="panel" style={{ padding: "10px 14px", display: "flex", gap: 12, alignItems: "center", fontSize: 13, background: "var(--paper)" }}>
         <span style={{ color: "var(--muted)", fontSize: 12 }}>Slash command</span>
-        <code style={{ background: "var(--code-bg)", color: "#e2e8f0", padding: "4px 10px", borderRadius: 6, fontSize: 12 }}>{slashCommand(entity)}</code>
+        <code style={{ background: "var(--code-bg)", color: "var(--code-fg)", padding: "4px 10px", borderRadius: 6, fontSize: 12 }}>{slashCommand(entity)}</code>
       </div>
       <InputPanel entity={entity} collapsed />
       <LogsPanel logs={entity.logs} polling />

--- a/src/client/pages/Install.tsx
+++ b/src/client/pages/Install.tsx
@@ -2,6 +2,22 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { Manifest } from "@shared/types";
 
+interface ExamplePackage {
+  pkg: string;
+  icon: string;
+  name: string;
+  desc: string;
+}
+
+// Placeholder community packages — the registry concept before a real registry
+// exists. Clicking one prefills the package name input.
+const EXAMPLE_PACKAGES: ExamplePackage[] = [
+  { pkg: "claudepanion-oncall",   icon: "🚨", name: "On-call Investigator", desc: "Query CloudWatch + PagerDuty, triage alerts, suggest root causes." },
+  { pkg: "claudepanion-standup",  icon: "💬", name: "Standup Summarizer",   desc: "Read Slack channel history, draft a standup, optionally post it back." },
+  { pkg: "claudepanion-spend",    icon: "💸", name: "AWS Spend Watcher",    desc: "Query Cost Explorer daily, flag anomalies, email a digest." },
+  { pkg: "claudepanion-reviewer", icon: "🔎", name: "PR Reviewer",          desc: "Review GitHub PRs, flag risky diffs, suggest review questions." },
+];
+
 export default function Install() {
   const [pkg, setPkg] = useState("");
   const [state, setState] = useState<"idle" | "installing" | "success" | "error">("idle");
@@ -36,45 +52,231 @@ export default function Install() {
     }
   };
 
-  return (
-    <>
-      <div className="breadcrumb">Install</div>
-      <div className="page-title">
-        <h1>Install companion from npm</h1>
-      </div>
-      <form onSubmit={submit} style={{ maxWidth: 560, display: "flex", flexDirection: "column", gap: 12 }}>
-        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 13 }}>
-          Package name
-          <input
-            value={pkg}
-            onChange={(e) => setPkg(e.target.value)}
-            placeholder="claudepanion-oncall"
-            style={{ padding: 8, border: "1px solid #cbd5e1", borderRadius: 6 }}
-          />
-          <span style={{ fontSize: 11, color: "#64748b" }}>Must start with <code>claudepanion-</code>.</span>
-        </label>
-        <button className="btn" type="submit" disabled={!valid || state === "installing"} style={{ alignSelf: "flex-start" }}>
-          {state === "installing" ? "Installing…" : "Install"}
-        </button>
+  const inputBorder =
+    state === "error" ? "rgba(192, 70, 61, 0.55)"
+    : state === "success" ? "rgba(122, 135, 136, 0.55)"
+    : "rgba(21, 24, 26, 0.15)";
 
-        {state === "error" && error && (
-          <pre style={{ background: "#fef2f2", color: "#991b1b", padding: 12, borderRadius: 8, fontSize: 12, whiteSpace: "pre-wrap", maxWidth: 720 }}>
-            {error}
-          </pre>
-        )}
-        {state === "success" && installed && (
-          <div style={{ background: "#f0fdf4", border: "1px solid #bbf7d0", color: "#166534", padding: 12, borderRadius: 8 }}>
-            <div style={{ fontWeight: 600 }}>Installed {installed.icon} {installed.displayName} v{installed.version}</div>
-            <button
-              type="button"
-              onClick={() => navigate(`/c/${installed.name}`)}
-              style={{ marginTop: 8, background: "white", border: "1px solid #86efac", color: "#166534", padding: "6px 12px", borderRadius: 6, fontSize: 13, cursor: "pointer" }}
-            >
-              Open →
-            </button>
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 28 }}>
+      <div className="breadcrumb">
+        <span>claudepanion</span>
+        <span className="breadcrumb-sep">›</span>
+        <span style={{ color: "var(--ink)" }}>Install companion</span>
+      </div>
+
+      <div>
+        <h1 className="serif" style={{ fontSize: 52, lineHeight: 1.0, margin: "0 0 12px" }}>
+          Install from <span className="serif-italic" style={{ color: "var(--accent)" }}>npm</span>.
+        </h1>
+        <p style={{ fontSize: 15, color: "var(--muted)", margin: 0, maxWidth: 600, lineHeight: 1.55 }}>
+          Any npm package named <code style={chip}>claudepanion-*</code> can be installed here. The host runs <code style={chip}>npm install</code>, validates the companion contract, and mounts it in the sidebar — no restart needed.
+        </p>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 320px", gap: 40, alignItems: "start" }}>
+        <div>
+          {/* Install form */}
+          <form
+            onSubmit={submit}
+            className="card"
+            style={{ padding: "22px 24px", marginBottom: 24 }}
+          >
+            <div className="eyebrow" style={{ marginBottom: 14 }}>Package name</div>
+            <div style={{ display: "flex", gap: 10, marginBottom: 8 }}>
+              <input
+                value={pkg}
+                onChange={(e) => setPkg(e.target.value)}
+                placeholder="claudepanion-oncall"
+                disabled={state === "installing"}
+                style={{
+                  flex: 1,
+                  padding: "10px 14px",
+                  border: `1px solid ${inputBorder}`,
+                  borderRadius: 6,
+                  fontSize: 14,
+                  fontFamily: "var(--font-mono)",
+                  background: "var(--bg)",
+                  color: "var(--ink)",
+                  transition: "border-color 0.15s ease, box-shadow 0.15s ease",
+                }}
+              />
+              <button
+                type="submit"
+                className="btn"
+                disabled={!valid || state === "installing"}
+                style={{ borderRadius: 6, display: "inline-flex", alignItems: "center", gap: 8, whiteSpace: "nowrap" }}
+              >
+                {state === "installing" && <Spinner />}
+                {state === "installing" ? "Installing…" : "Install"}
+              </button>
+            </div>
+            <div style={{ fontSize: 11, color: "var(--muted)" }}>
+              Must start with <code style={chip}>claudepanion-</code> · any valid npm package name
+            </div>
+
+            {state === "installing" && (
+              <div
+                style={{
+                  marginTop: 16,
+                  padding: "12px 14px",
+                  background: "var(--soft)",
+                  borderRadius: 6,
+                  fontSize: 13,
+                  color: "var(--muted)",
+                  display: "flex",
+                  gap: 10,
+                  alignItems: "center",
+                }}
+              >
+                <Spinner />
+                <span>
+                  Running <code style={chip}>npm install {pkg}</code>…
+                </span>
+              </div>
+            )}
+
+            {state === "success" && installed && (
+              <div
+                style={{
+                  marginTop: 16,
+                  padding: "14px 16px",
+                  background: "rgba(122, 135, 136, 0.1)",
+                  border: "1px solid rgba(122, 135, 136, 0.3)",
+                  borderRadius: 8,
+                }}
+              >
+                <div style={{ fontWeight: 600, color: "var(--sage)", marginBottom: 4, fontSize: 14 }}>
+                  ✓ Installed {installed.icon} {installed.displayName} v{installed.version}
+                </div>
+                <div style={{ fontSize: 12, color: "var(--muted)", marginBottom: 10 }}>
+                  Mounted in the sidebar. No restart needed.
+                </div>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/c/${installed.name}`)}
+                  className="btn"
+                  style={{ borderRadius: 6, padding: "7px 14px", fontSize: 12, minHeight: 0 }}
+                >
+                  Open companion →
+                </button>
+              </div>
+            )}
+
+            {state === "error" && error && (
+              <div
+                style={{
+                  marginTop: 16,
+                  padding: "12px 14px",
+                  background: "rgba(192, 70, 61, 0.06)",
+                  border: "1px solid rgba(192, 70, 61, 0.3)",
+                  borderRadius: 8,
+                }}
+              >
+                <div style={{ fontWeight: 600, color: "#C0463D", marginBottom: 6, fontSize: 13 }}>
+                  Install failed
+                </div>
+                <pre
+                  style={{
+                    margin: 0,
+                    fontSize: 11,
+                    fontFamily: "var(--font-mono)",
+                    color: "var(--muted)",
+                    whiteSpace: "pre-wrap",
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {error}
+                </pre>
+              </div>
+            )}
+          </form>
+
+          {/* How it works */}
+          <div style={{ fontSize: 13, color: "var(--muted)", lineHeight: 1.7 }}>
+            <div className="eyebrow" style={{ marginBottom: 10 }}>How it works</div>
+            <ol style={{ margin: 0, paddingLeft: 20, display: "flex", flexDirection: "column", gap: 4 }}>
+              <li>Type any <code style={chip}>claudepanion-*</code> package name</li>
+              <li>The host runs <code style={chip}>npm install</code> and dynamically imports it</li>
+              <li>The companion contract is validated (manifest, form, tools)</li>
+              <li>It mounts in the sidebar without a restart</li>
+              <li>The install is persisted to <code style={chip}>companions/index.ts</code></li>
+            </ol>
           </div>
-        )}
-      </form>
-    </>
+        </div>
+
+        {/* Community packages aside */}
+        <aside>
+          <div className="eyebrow" style={{ marginBottom: 12 }}>Community packages</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            {EXAMPLE_PACKAGES.map((p) => (
+              <button
+                key={p.pkg}
+                type="button"
+                onClick={() => setPkg(p.pkg)}
+                disabled={state === "installing"}
+                className="card-bordered"
+                style={{
+                  padding: "14px 16px",
+                  textAlign: "left",
+                  fontFamily: "inherit",
+                  font: "inherit",
+                  color: "inherit",
+                  cursor: state === "installing" ? "not-allowed" : "pointer",
+                  display: "flex",
+                  gap: 12,
+                  alignItems: "flex-start",
+                  background: "var(--bg)",
+                }}
+              >
+                <span style={{ fontSize: 22, flexShrink: 0 }} aria-hidden="true">{p.icon}</span>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontWeight: 600, fontSize: 13, color: "var(--ink)", marginBottom: 2 }}>{p.name}</div>
+                  <div style={{ fontSize: 11, color: "var(--muted)", lineHeight: 1.45, marginBottom: 6 }}>{p.desc}</div>
+                  <div className="mono" style={{ fontSize: 10, color: "var(--muted)" }}>{p.pkg}</div>
+                </div>
+              </button>
+            ))}
+          </div>
+          <div style={{ marginTop: 12, fontSize: 11, color: "var(--muted)", lineHeight: 1.55 }}>
+            The registry is npm. Search{" "}
+            <a
+              href="https://www.npmjs.com/search?q=claudepanion-"
+              target="_blank"
+              rel="noreferrer noopener"
+              style={{ color: "var(--accent)", textDecoration: "none" }}
+            >
+              npmjs.com/search?q=claudepanion-
+            </a>{" "}
+            for more.
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+const chip: React.CSSProperties = {
+  background: "var(--soft)",
+  padding: "2px 7px",
+  borderRadius: 4,
+  fontSize: "0.9em",
+  fontFamily: "var(--font-mono)",
+};
+
+function Spinner() {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display: "inline-block",
+        width: 14,
+        height: 14,
+        border: "2px solid currentColor",
+        borderTopColor: "transparent",
+        borderRadius: "50%",
+        animation: "spin 0.8s linear infinite",
+      }}
+    />
   );
 }

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -73,7 +73,7 @@ code, pre, .mono { font-family: var(--font-mono); }
   color: var(--accent);
 }
 
-.app { display: flex; min-height: 100vh; }
+.app { display: flex; height: 100vh; overflow: hidden; }
 .app-sidebar {
   width: 240px;
   background: var(--sidebar-bg);
@@ -84,11 +84,12 @@ code, pre, .mono { font-family: var(--font-mono); }
   display: flex;
   flex-direction: column;
   font-family: var(--font-sans);
+  overflow-y: auto;
 }
 .app-main {
   flex: 1;
   padding: 32px 48px;
-  overflow: auto;
+  overflow-y: auto;
   min-width: 0;
 }
 

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -1,12 +1,19 @@
 :root {
-  --bg: #ffffff;
-  --fg: #0f172a;
-  --muted: #64748b;
-  --border: #e2e8f0;
-  --brand: #0369a1;
-  --sidebar: #0f172a;
-  --sidebar-fg: #cbd5e1;
-  --sidebar-active: #1e293b;
+  /* === Editorial · Cool palette === */
+  --bg: #F1F2F1;
+  --fg: #15181A;
+  --ink: #15181A;
+  --muted: #5C6266;
+  --soft: #DDE2DE;
+  --border: #DDE2DE;
+  --paper: #F6F7F4;
+  --accent: #3D6FB8;
+  --brand: #3D6FB8;
+  --sage: #7A8788;
+  --code-bg: #181C1E;
+  --code-fg: #C8D0D4;
+
+  /* Status — kept for compatibility but visually toned for editorial */
   --pending-bg: #e2e8f0;
   --pending-fg: #475569;
   --running-bg: #fef3c7;
@@ -15,25 +22,141 @@
   --completed-fg: #166534;
   --error-bg: #fee2e2;
   --error-fg: #991b1b;
-  --code-bg: #0c1220;
-  --code-fg: #cbd5e1;
+
+  /* Sidebar (paper, not dark) */
+  --sidebar-bg: var(--paper);
+  --sidebar-fg: var(--ink);
+
+  /* Typography */
+  --font-serif: 'Instrument Serif', Georgia, serif;
+  --font-sans: 'Inter', system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 * { box-sizing: border-box; }
-body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, sans-serif; color: var(--fg); background: var(--bg); }
-code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--fg);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+code, pre, .mono { font-family: var(--font-mono); }
+
+.serif { font-family: var(--font-serif); font-weight: 400; letter-spacing: -0.01em; }
+.serif-italic { font-family: var(--font-serif); font-style: italic; font-weight: 400; }
+
+/* Eyebrow tag — uppercase mono caption used to label sections */
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.eyebrow-pill {
+  display: inline-block;
+  padding: 3px 10px;
+  border: 1px solid rgba(21, 24, 26, 0.15);
+  border-radius: 999px;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.eyebrow-pill-accent {
+  border-color: rgba(61, 111, 184, 0.4);
+  color: var(--accent);
+}
 
 .app { display: flex; min-height: 100vh; }
-.app-sidebar { width: 220px; background: var(--sidebar); color: var(--sidebar-fg); padding: 16px 0; flex-shrink: 0; display: flex; flex-direction: column; }
-.app-main { flex: 1; padding: 24px 28px; overflow: auto; min-width: 0; }
+.app-sidebar {
+  width: 240px;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-fg);
+  border-right: 1px solid rgba(21, 24, 26, 0.08);
+  padding: 20px 0;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-sans);
+}
+.app-main {
+  flex: 1;
+  padding: 32px 48px;
+  overflow: auto;
+  min-width: 0;
+}
 
-.sidebar-logo { padding: 0 16px 16px; display: flex; align-items: center; gap: 8px; color: #fff; font-weight: 600; }
-.sidebar-logo-icon { width: 22px; height: 22px; background: var(--brand); border-radius: 6px; }
-.sidebar-section-label { padding: 4px 12px; font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #94a3b8; margin-top: 8px; }
-.sidebar-link { padding: 10px 16px; display: flex; align-items: center; gap: 8px; color: var(--sidebar-fg); text-decoration: none; cursor: pointer; font-size: 13px; min-height: 40px; }
-.sidebar-link:hover { background: #1a2438; color: #fff; }
-.sidebar-link.active { background: var(--sidebar-active); color: #fff; border-left: 3px solid var(--brand); padding-left: 13px; }
-.sidebar-footer { margin-top: auto; padding-top: 12px; border-top: 1px solid rgba(255, 255, 255, 0.14); }
+/* === Sidebar (editorial, paper bg) === */
+.sidebar-logo {
+  padding: 0 16px 4px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+}
+.sidebar-logo-icon {
+  width: 22px;
+  height: 22px;
+  background: var(--accent);
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+.sidebar-logo-name { font-weight: 600; font-size: 14px; letter-spacing: -0.01em; }
+.sidebar-logo-sub { padding: 2px 16px 12px 48px; font-family: var(--font-mono); font-size: 10px; color: var(--muted); }
+
+.sidebar-section-label {
+  padding: 12px 16px 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+.sidebar-section-empty {
+  padding: 4px 16px 8px;
+  font-size: 11px;
+  color: var(--muted);
+  font-style: italic;
+  line-height: 1.5;
+}
+.sidebar-link {
+  padding: 10px 16px 10px 13px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+  text-decoration: none;
+  cursor: pointer;
+  font-size: 13px;
+  min-height: 40px;
+  border-left: 3px solid transparent;
+  transition: background 0.15s ease;
+}
+.sidebar-link:hover { background: rgba(21, 24, 26, 0.04); }
+.sidebar-link.active {
+  background: rgba(61, 111, 184, 0.1);
+  border-left-color: var(--accent);
+}
+.sidebar-link-muted { color: var(--muted); }
+.sidebar-link-icon { font-size: 14px; flex-shrink: 0; }
+
+.sidebar-footer {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid rgba(21, 24, 26, 0.08);
+}
+.sidebar-footnote {
+  padding: 10px 16px 4px;
+  font-size: 10px;
+  color: var(--muted);
+  line-height: 1.5;
+}
 
 a:focus-visible,
 button:focus-visible,
@@ -41,96 +164,347 @@ input:focus-visible,
 select:focus-visible,
 textarea:focus-visible,
 [tabindex]:focus-visible {
-  outline: 2px solid var(--brand);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: 4px;
 }
-.app-sidebar a:focus-visible,
-.app-sidebar button:focus-visible {
-  outline-color: #38bdf8;
-}
 
-/* visually-hidden for a11y headings */
 .vh { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 
-.breadcrumb { font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+.breadcrumb {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 6px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.breadcrumb a { color: var(--muted); text-decoration: none; }
+.breadcrumb a:hover { color: var(--ink); }
+.breadcrumb-sep { opacity: 0.4; }
+
 .page-title { display: flex; justify-content: space-between; align-items: center; margin: 0 0 20px; gap: 12px; flex-wrap: wrap; }
 .page-title h1, .page-title h2, .page-title h3 { margin: 0; }
-.btn { min-height: 36px; }
-.btn-outline { background: #fff; border: 1px solid #cbd5e1; color: #334155; border-radius: 6px; padding: 8px 14px; font-size: 13px; font-weight: 500; cursor: pointer; min-height: 36px; }
-.btn-outline:hover { background: #f8fafc; }
+
+.btn {
+  background: var(--ink);
+  color: var(--bg);
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  min-height: 38px;
+  transition: background 0.15s ease;
+}
+.btn:hover { background: rgba(21, 24, 26, 0.85); }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-outline {
+  background: transparent;
+  border: 1px solid rgba(21, 24, 26, 0.2);
+  color: var(--ink);
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  min-height: 38px;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.btn-outline:hover { background: var(--paper); border-color: rgba(21, 24, 26, 0.35); }
+.btn-secondary { background: var(--paper); color: var(--ink); border: 1px solid rgba(21, 24, 26, 0.2); }
 
 .form-error { color: var(--error-fg); font-size: 12px; margin-top: 4px; min-height: 1em; }
 
-.entity-list-header { display: grid; grid-template-columns: 100px 1fr 120px; font-size: 12px; color: var(--muted); font-weight: 400; background: #f8fafc; }
-.entity-list-row { display: grid; grid-template-columns: 100px 1fr 120px; padding: 12px 14px; border-top: 1px solid var(--border); align-items: center; font-size: 13px; text-decoration: none; color: inherit; gap: 12px; }
-.entity-list-row:hover { background: #f8fafc; }
+.entity-list-header {
+  display: grid;
+  grid-template-columns: 100px 1fr 120px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: var(--paper);
+  padding: 10px 18px;
+  border-bottom: 1px solid rgba(21, 24, 26, 0.08);
+  gap: 14px;
+}
+.entity-list-row {
+  display: grid;
+  grid-template-columns: 100px 1fr 120px;
+  padding: 14px 18px;
+  border-top: 1px dashed rgba(21, 24, 26, 0.08);
+  align-items: center;
+  font-size: 13px;
+  text-decoration: none;
+  color: inherit;
+  gap: 14px;
+  transition: background 0.15s ease;
+}
+.entity-list-row:hover { background: var(--paper); }
 
 @media (max-width: 768px) {
   .app { flex-direction: column; }
-  .app-sidebar { width: 100%; flex-direction: row; flex-wrap: wrap; padding: 8px; gap: 4px; align-items: center; }
+  .app-sidebar {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding: 8px;
+    gap: 4px;
+    align-items: center;
+    border-right: 0;
+    border-bottom: 1px solid rgba(21, 24, 26, 0.08);
+  }
   .sidebar-logo { padding: 4px 8px; flex-basis: 100%; }
+  .sidebar-logo-sub { display: none; }
   .sidebar-section-label { display: none; }
-  .sidebar-link { padding: 8px 12px; min-height: 36px; font-size: 12px; }
-  .sidebar-link.active { border-left: 0; border-bottom: 2px solid var(--brand); padding-left: 12px; }
-  .sidebar-footer { margin-top: 0; padding-top: 0; border-top: 0; border-left: 1px solid rgba(255,255,255,0.14); padding-left: 8px; margin-left: auto; }
+  .sidebar-section-empty { display: none; }
+  .sidebar-link { padding: 8px 12px; min-height: 36px; font-size: 12px; border-left: 0; }
+  .sidebar-link.active { border-left: 0; border-bottom: 2px solid var(--accent); }
+  .sidebar-footer { margin-top: 0; padding-top: 0; border-top: 0; border-left: 1px solid rgba(21, 24, 26, 0.08); padding-left: 8px; margin-left: auto; }
+  .sidebar-footnote { display: none; }
   .app-main { padding: 16px; }
   .page-title { flex-direction: column; align-items: stretch; }
   .entity-list-header, .entity-list-row { grid-template-columns: 80px 1fr; }
   .entity-list-updated { display: none; }
 }
 
-.btn { background: var(--brand); color: #fff; border: 0; border-radius: 6px; padding: 8px 14px; font-size: 13px; font-weight: 500; cursor: pointer; }
-.btn-secondary { background: #fff; color: #334155; border: 1px solid #cbd5e1; }
-.btn:disabled { opacity: .5; cursor: not-allowed; }
-
-.status-pill { padding: 4px 12px; border-radius: 999px; font-size: 12px; display: inline-flex; align-items: center; gap: 6px; }
+.status-pill {
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+}
+.status-pill::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  display: inline-block;
+}
 .status-pill.pending { background: var(--pending-bg); color: var(--pending-fg); }
 .status-pill.running { background: var(--running-bg); color: var(--running-fg); }
 .status-pill.completed { background: var(--completed-bg); color: var(--completed-fg); }
 .status-pill.error { background: var(--error-bg); color: var(--error-fg); }
 
-.slash-command { background: linear-gradient(180deg, #f0f9ff 0%, #e0f2fe 100%); border: 1px solid #bae6fd; border-radius: 10px; padding: 20px; margin-bottom: 20px; }
-.slash-command-label { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #0369a1; margin-bottom: 6px; }
-.slash-command-hint { font-size: 14px; color: #075985; margin-bottom: 14px; }
-.slash-command-row { display: flex; gap: 8px; align-items: stretch; }
-.slash-command-code { flex: 1; background: var(--code-bg); color: #e2e8f0; border-radius: 8px; padding: 14px 16px; font-family: ui-monospace, monospace; font-size: 14px; display: flex; align-items: center; }
-.slash-command-copy { background: var(--brand); color: #fff; border: 0; border-radius: 8px; padding: 0 18px; font-weight: 600; cursor: pointer; font-size: 13px; }
-.slash-command-note { margin-top: 12px; font-size: 12px; color: #075985; background: rgba(255, 255, 255, 0.55); border-left: 3px solid #0369a1; padding: 8px 12px; border-radius: 4px; line-height: 1.5; }
+.slash-command {
+  background: linear-gradient(160deg, rgba(122, 135, 136, 0.08) 0%, rgba(122, 135, 136, 0.04) 100%);
+  border: 1px solid rgba(122, 135, 136, 0.4);
+  border-radius: 10px;
+  padding: 22px 24px;
+  margin-bottom: 16px;
+}
+.slash-command-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--sage);
+  margin-bottom: 6px;
+}
+.slash-command-hint { font-size: 14px; color: var(--ink); margin-bottom: 14px; line-height: 1.45; }
+.slash-command-row { display: flex; gap: 10px; align-items: stretch; }
+.slash-command-code {
+  flex: 1;
+  background: var(--code-bg);
+  color: var(--code-fg);
+  border-radius: 7px;
+  padding: 13px 16px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+}
+.slash-command-copy {
+  background: var(--ink);
+  color: var(--bg);
+  border: 0;
+  border-radius: 7px;
+  padding: 0 20px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.slash-command-note {
+  margin-top: 12px;
+  padding: 10px 14px;
+  background: var(--paper);
+  border-left: 3px solid var(--sage);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+.slash-command-note strong { color: var(--ink); }
+.slash-command-note code {
+  background: var(--soft);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 11px;
+}
 
-.status-bar { background: #fffbeb; border: 1px solid #fcd34d; border-radius: 10px; padding: 14px 16px; margin-bottom: 16px; display: flex; align-items: center; gap: 12px; }
-.status-bar-dot { width: 8px; height: 8px; background: #d97706; border-radius: 50%; flex-shrink: 0; }
-.status-bar-label { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #92400e; }
-.status-bar-message { font-size: 14px; color: #78350f; margin-top: 2px; }
+.status-bar {
+  background: rgba(61, 111, 184, 0.06);
+  border: 1px solid rgba(61, 111, 184, 0.25);
+  border-radius: 8px;
+  padding: 13px 16px;
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.status-bar-dot {
+  width: 8px;
+  height: 8px;
+  background: var(--accent);
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: dapulse 1.2s infinite;
+}
+@keyframes dapulse {
+  0% { box-shadow: 0 0 0 0 rgba(61, 111, 184, 0.4); }
+  70% { box-shadow: 0 0 0 8px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+.status-bar-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+}
+.status-bar-message { font-size: 14px; color: var(--ink); margin-top: 2px; }
 
-.panel { border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 16px; }
-.panel-header { padding: 12px 16px; border-bottom: 1px solid var(--border); font-weight: 600; font-size: 14px; display: flex; justify-content: space-between; align-items: center; }
+.panel {
+  border: 1px solid rgba(21, 24, 26, 0.08);
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 14px;
+  background: var(--bg);
+}
+.panel-header {
+  padding: 11px 16px;
+  border-bottom: 1px solid rgba(21, 24, 26, 0.06);
+  font-weight: 600;
+  font-size: 13px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--paper);
+}
 .panel-body { padding: 14px 16px; }
 
-.logs { background: var(--code-bg); color: var(--code-fg); font-family: ui-monospace, monospace; font-size: 12px; padding: 12px 16px; max-height: 280px; overflow: auto; line-height: 1.55; }
-.log-ts { color: #64748b; }
-.log-level-info { color: #7dd3fc; }
-.log-level-warn { color: #eab308; }
-.log-level-error { color: #f87171; }
+.logs {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 12px 16px;
+  max-height: 280px;
+  overflow: auto;
+  line-height: 1.65;
+}
+.log-ts { color: #4B5563; }
+.log-level-info { color: #7DD3FC; }
+.log-level-warn { color: #FDE047; }
+.log-level-error { color: #F87171; }
 
-.stale-badge { display: inline-block; margin-left: 8px; background: #fee2e2; color: #991b1b; padding: 2px 8px; border-radius: 999px; font-size: 11px; }
+.stale-badge {
+  display: inline-block;
+  margin-left: 8px;
+  background: var(--error-bg);
+  color: var(--error-fg);
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+}
 
-.continuation { border: 1px solid var(--border); border-radius: 8px; padding: 16px; margin-bottom: 16px; background: #fff; }
+.continuation {
+  border: 1px solid rgba(21, 24, 26, 0.08);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background: var(--paper);
+}
 .continuation-title { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
 .continuation-hint { font-size: 12px; color: var(--muted); margin-bottom: 10px; }
 .continuation-row { display: flex; gap: 8px; }
-.continuation-input { flex: 1; border: 1px solid #cbd5e1; border-radius: 6px; padding: 8px 10px; font-size: 13px; }
+.continuation-input {
+  flex: 1;
+  border: 1px solid rgba(21, 24, 26, 0.15);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 13px;
+  background: var(--bg);
+}
+.continuation-input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px rgba(61, 111, 184, 0.15); }
 
-.error-hero { border: 1px solid #fecaca; border-radius: 10px; margin-bottom: 16px; overflow: hidden; }
-.error-hero-header { background: linear-gradient(180deg, #fef2f2 0%, #fee2e2 100%); padding: 16px 18px; border-bottom: 1px solid #fecaca; }
-.error-hero-label { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #991b1b; margin-bottom: 4px; }
-.error-hero-message { font-size: 14px; color: #7f1d1d; font-weight: 500; }
-.error-hero-stack { background: var(--code-bg); color: #fca5a5; font-family: ui-monospace, monospace; font-size: 12px; padding: 12px 14px; border-radius: 6px; line-height: 1.5; white-space: pre-wrap; margin: 16px 18px; }
+.error-hero {
+  border: 1px solid rgba(227, 102, 88, 0.4);
+  border-radius: 10px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+.error-hero-header {
+  background: linear-gradient(160deg, rgba(227, 102, 88, 0.1), rgba(227, 102, 88, 0.04));
+  padding: 14px 18px;
+  border-bottom: 1px solid rgba(227, 102, 88, 0.3);
+}
+.error-hero-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #C0463D;
+  margin-bottom: 4px;
+}
+.error-hero-message { font-size: 14px; color: var(--ink); font-weight: 500; }
+.error-hero-stack {
+  background: var(--code-bg);
+  color: #fca5a5;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 12px 14px;
+  border-radius: 6px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  margin: 16px 18px;
+}
 
-.artifact-hero { border: 1px solid #bbf7d0; border-radius: 10px; margin-bottom: 16px; overflow: hidden; }
-.artifact-hero-header { background: linear-gradient(180deg, #f0fdf4 0%, #dcfce7 100%); padding: 14px 18px; border-bottom: 1px solid #bbf7d0; }
-.artifact-hero-label { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #166534; }
-.artifact-hero-title { font-size: 14px; color: #14532d; margin-top: 2px; }
+.artifact-hero {
+  border: 1px solid rgba(122, 135, 136, 0.5);
+  border-radius: 10px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+.artifact-hero-header {
+  background: linear-gradient(160deg, rgba(122, 135, 136, 0.15), rgba(122, 135, 136, 0.06));
+  padding: 14px 18px;
+  border-bottom: 1px solid rgba(122, 135, 136, 0.3);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+.artifact-hero-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--sage);
+}
+.artifact-hero-title { font-size: 14px; color: var(--ink); margin-top: 2px; font-weight: 500; }
 .artifact-hero-body { padding: 18px; }
 
 .preflight-banner {
@@ -140,13 +514,13 @@ textarea:focus-visible,
   font-size: 14px;
 }
 .preflight-banner-blocking {
-  background: #fef2f2;
-  border: 1px solid #fecaca;
+  background: rgba(227, 102, 88, 0.08);
+  border: 1px solid rgba(227, 102, 88, 0.3);
   color: #991b1b;
 }
 .preflight-banner-soft {
-  background: #fefce8;
-  border: 1px solid #fde68a;
+  background: rgba(229, 162, 74, 0.08);
+  border: 1px solid rgba(229, 162, 74, 0.3);
   color: #854d0e;
 }
 .preflight-banner code {
@@ -155,17 +529,17 @@ textarea:focus-visible,
   border-radius: 4px;
 }
 .artifact-summary-banner {
-  background: #f0fdf4;
-  border: 1px solid #bbf7d0;
-  color: #14532d;
+  background: rgba(122, 135, 136, 0.1);
+  border: 1px solid rgba(122, 135, 136, 0.3);
+  color: var(--ink);
   padding: 10px 14px;
   border-radius: 8px;
   margin-bottom: 12px;
   font-size: 14px;
 }
 .artifact-errors {
-  background: #fefce8;
-  border: 1px solid #fde68a;
+  background: rgba(229, 162, 74, 0.08);
+  border: 1px solid rgba(229, 162, 74, 0.3);
   border-radius: 8px;
   padding: 10px 14px;
   margin-top: 12px;
@@ -192,19 +566,33 @@ textarea:focus-visible,
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
-.badge-read {
-  background: #f1f5f9;
-  color: #475569;
-}
-.badge-write {
-  background: #fee2e2;
-  color: #991b1b;
-}
+.badge-read { background: var(--soft); color: var(--muted); }
+.badge-write { background: rgba(227, 102, 88, 0.12); color: #991b1b; }
 .write-tools-warning {
-  background: #fef2f2;
-  border: 1px solid #fecaca;
+  background: rgba(227, 102, 88, 0.08);
+  border: 1px solid rgba(227, 102, 88, 0.3);
   color: #991b1b;
   padding: 12px 16px;
   border-radius: 8px;
   font-size: 14px;
+}
+
+/* Editorial card primitives */
+.card {
+  background: var(--paper);
+  border: 1px solid rgba(21, 24, 26, 0.08);
+  border-radius: 8px;
+  padding: 20px 22px;
+}
+.card-bordered {
+  background: var(--bg);
+  border: 1px solid rgba(21, 24, 26, 0.1);
+  border-radius: 8px;
+  padding: 20px 22px;
+  transition: border-color 0.15s ease, transform 0.15s ease, background 0.15s ease;
+}
+.card-bordered:hover {
+  border-color: var(--accent);
+  background: var(--paper);
+  transform: translateY(-2px);
 }

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -376,6 +376,10 @@ textarea:focus-visible,
   70% { box-shadow: 0 0 0 8px transparent; }
   100% { box-shadow: 0 0 0 0 transparent; }
 }
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
 .status-bar-label {
   font-family: var(--font-mono);
   font-size: 10px;

--- a/tests/client/BuildForm.test.tsx
+++ b/tests/client/BuildForm.test.tsx
@@ -31,12 +31,13 @@ describe("BuildForm ?example= prefill", () => {
     renderAt("/c/build/new?example=github-pr-reviewer");
     const name = await screen.findByLabelText(/companion name/i) as HTMLInputElement;
     const description = await screen.findByLabelText(/^description$/i) as HTMLTextAreaElement;
-    const kind = await screen.findByLabelText(/kind/i) as HTMLSelectElement;
     await waitFor(() => {
       expect(name.value).toBe("github-pr-reviewer");
-      expect(kind.value).toBe("entity");
       expect(description.value).toMatch(/flag risky diffs/i);
     });
+    // Kind picker is two role="radio" buttons; the prefilled example is "entity".
+    const entityBtn = screen.getByRole("radio", { name: /entity\s+form, lifecycle/i });
+    expect(entityBtn).toHaveAttribute("aria-checked", "true");
   });
 
   it("falls back to an empty form when example slug is unknown", async () => {

--- a/tests/client/CompanionAbout.test.tsx
+++ b/tests/client/CompanionAbout.test.tsx
@@ -18,6 +18,7 @@ beforeEach(() => {
         { name: "demo_post_thing", description: "Post a thing.", params: [], signature: "demo_post_thing()", sideEffect: "write" },
       ],
     }), { status: 200 });
+    if (url.startsWith("/api/entities?companion=")) return new Response(JSON.stringify([]), { status: 200 });
     throw new Error(`unexpected: ${url}`);
   }));
 });
@@ -71,6 +72,7 @@ describe("CompanionAbout", () => {
         manifest: { name: "ro", kind: "entity", displayName: "RO", icon: "🔍", description: "", contractVersion: "1", version: "0.1.0" },
         tools: [{ name: "ro_get", description: "read", params: [], signature: "ro_get()", sideEffect: "read" }],
       }), { status: 200 });
+      if (url.startsWith("/api/entities?companion=")) return new Response(JSON.stringify([]), { status: 200 });
       throw new Error(`unexpected: ${url}`);
     }));
     render(


### PR DESCRIPTION
## Summary

Implements the **Editorial · Cool** design handoff across the app screens (landing page intentionally deferred). Four screens redone end-to-end on top of a new design-token foundation:

- **Foundation** (b3e53d3) — Google Fonts (Instrument Serif / Inter / JetBrains Mono), cool palette as CSS variables, hand-sketched 1.4-stroke SVG icon set, paper-bg sidebar with Core/Companions/Tools sections + footnoted footer.
- **Build home** (5106ed9) — `/c/build` is now a dedicated `BuildHome.tsx` with serif "Hi, *I'm Build*" hero, two-mode card row, chip grid, and inline past-builds table fetched from `/api/entities`. Build's form has serif headline, mode tabs, kind picker as `role="radio"` cards (was a `<select>`), and an ink-pill submit. Entity detail picks up the new typography.
- **Generic companion home + Install** (7d03d5d) — `CompanionAbout` for non-build entity companions: icon-square header, version/run-count meta, "🔨 Iterate with Build / + New run" CTAs, inline runs table or empty state. `/install` redesigned with serif "Install from npm." hero, clickable community-package aside that prefills the input, and inline state panels for idle/installing/success/error. MCP tools list and Danger zone preserved.
- **Sidebar viewport lock** (c0333eb) — sidebar is now `height: 100vh` with its own scroll; "+ Install companion" no longer hides below the page fold.

## Test plan
- [ ] `npm run build` clean
- [ ] `npx vitest run` — 136/136 passing
- [ ] `/c/build` — hero, mode cards, chips, real entities listed in past-builds table
- [ ] `/c/build/new` — kind picker shows two cards, prefilled chip flow still works (`?example=…`)
- [ ] `/c/<entity-companion>` — header + runs table or empty state, MCP tools section, Remove button still functional
- [ ] `/install` — typing `claudepanion-foo` enables Install; clicking a community-package card prefills the input; spinner shows during install
- [ ] Sidebar: with a tall main page, "+ Install companion" stays visible at the bottom of the viewport without scrolling main
- [ ] No console errors / a11y warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)