### PR TITLE
Datetime form fix, MCP precondition gate, MCP-status banner

### DIFF
--- a/skills/build-companion/SKILL.md
+++ b/skills/build-companion/SKILL.md
@@ -13,9 +13,31 @@ Build is claudepanion's companion that scaffolds other companions.
 > - NEVER edit `data/build/*.json` directly.
 > - NEVER leave a placeholder like `<<<INSERT PLAYBOOK HERE>>>` in an authored file.
 > - NEVER mark `completed` until `claudepanion scaffold`'s self-check stage passed.
-> - If MCP tools aren't loaded, STOP and tell the user to verify `claudepanion plugin install` and start a new session.
 
 The reference doc for the contract you're authoring against is [`docs/scaffold-spec.md`](../../docs/scaffold-spec.md).
+
+## Step 0 — Verify the claudepanion MCP is connected
+
+**This MUST be the first thing you do. Do not skip it. Do not improvise around it.**
+
+Confirm `mcp__claudepanion__*` tools are available in this session before doing anything else. If Step 1 below (the `build_get` call) returns "tool not available", "MCP server not connected", a transport error, or any analogous failure:
+
+- **STOP. Do not continue past this step.**
+- **Do not** read files manually, run `git` / `grep` / Bash, or try to discover the entity any other way.
+- **Do not** start authoring scaffold files speculatively.
+- Tell the user the message below and wait for them to fix the connection before proceeding.
+
+> I can't reach the claudepanion MCP server. Try these in order:
+>
+> 1. Run `/mcp` in this session and check whether `claudepanion` is listed (and not in an error state).
+> 2. Confirm the claudepanion server is running — open <http://localhost:3001> or run `lsof -i :3001`. If it isn't, run `claudepanion serve`.
+> 3. Re-install the plugin in this repo: `claudepanion plugin install`.
+> 4. Rebuild the claudepanion checkout: `npm run build`.
+> 5. Start a **new** Claude Code session (plugins load at session start, not mid-session) and re-run `/mcp` to confirm — then re-paste the slash command.
+>
+> See [`docs/troubleshooting.md`](../../docs/troubleshooting.md) for more.
+
+The MCP server is the only supported channel for this skill. If it's unreachable, the work cannot proceed — there is no manual fallback.
 
 ## Step 1 — Load the entity
 
@@ -75,7 +97,7 @@ Author real domain content for each file based on Step 2's interpretation. No to
 | `companions/<slug>/manifest.ts` | `name`, `kind: "ui"`, `displayName`, `icon`, `description`, `contractVersion: "2"`, `version: "0.1.0"`, `requiredEnv`. |
 | `companions/<slug>/types.ts` | `InputSchema = z.object({...})` with `.describe()` and `.meta({ ui: ... })`. Optional `ArtifactExtras`. Default `Artifact = BaseArtifact;`. |
 | `companions/<slug>/server/tools.ts` | One `defineTool({...})` per proxy tool. Inline error classifier mapping the SDK's errors onto `[config]` / `[input]` / `[transient]`. `sideEffect: "write"` on write tools with explicit consequence in the description. |
-| `skills/<slug>-companion/SKILL.md` | Frontmatter + CRITICAL block + Steps 1–6. Step 4 is a sequenced playbook of `mcp__claudepanion__<slug>_*` tool calls + log lines — one sub-step per tool. Write tools get the user-permission stanza. |
+| `skills/<slug>-companion/SKILL.md` | Frontmatter + CRITICAL block + **Step 0 (verify MCP)** + Steps 1–6. Step 4 is a sequenced playbook of `mcp__claudepanion__<slug>_*` tool calls + log lines — one sub-step per tool. Write tools get the user-permission stanza. |
 
 After each file:
 ```
@@ -363,6 +385,18 @@ description: Use when the user pastes "/pr-reviewer-companion <entity-id>" — r
 # /pr-reviewer-companion <entity-id>
 
 > Read-only by default. Posts a review only when `postBack` is true AND the user explicitly confirms.
+
+## Step 0 — Verify the claudepanion MCP is connected
+
+**This MUST be the first thing you do.** If Step 1 below returns "tool not available", "MCP server not connected", or any analogous failure, **STOP**. Do not read files, run Bash, or investigate the PR manually. Tell the user:
+
+> I can't reach the claudepanion MCP server. Try these in order:
+>
+> 1. Run `/mcp` and check whether `claudepanion` is listed (and not errored).
+> 2. Confirm the claudepanion server is running — open <http://localhost:3001> or run `lsof -i :3001`. If not, run `claudepanion serve`.
+> 3. Re-install the plugin in this repo: `claudepanion plugin install`.
+> 4. Rebuild the claudepanion checkout: `npm run build`.
+> 5. Start a **new** Claude Code session and re-run `/mcp` to confirm — then re-paste the slash command.
 
 ## Step 1 — Load
 `mcp__claudepanion__pr_reviewer_get({ id })`

--- a/src/client/hooks/useMcpStatus.ts
+++ b/src/client/hooks/useMcpStatus.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+export interface McpStatus {
+  firstRequestAt: string | null;
+  lastRequestAt: string | null;
+  loading: boolean;
+}
+
+const INITIAL: McpStatus = { firstRequestAt: null, lastRequestAt: null, loading: true };
+const POLL_INTERVAL_MS = 5000;
+
+export function useMcpStatus(active: boolean): McpStatus {
+  const [status, setStatus] = useState<McpStatus>(INITIAL);
+
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+
+    const tick = async () => {
+      try {
+        const r = await fetch("/api/mcp/status");
+        if (cancelled) return;
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const data = await r.json();
+        setStatus({ firstRequestAt: data.firstRequestAt ?? null, lastRequestAt: data.lastRequestAt ?? null, loading: false });
+      } catch {
+        if (!cancelled) setStatus((s) => ({ ...s, loading: false }));
+      }
+    };
+
+    void tick();
+    const id = setInterval(tick, POLL_INTERVAL_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [active]);
+
+  return status;
+}

--- a/src/client/pages/EntityDetail.tsx
+++ b/src/client/pages/EntityDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useEntity } from "../hooks/useEntity";
+import { useMcpStatus } from "../hooks/useMcpStatus";
 import StatusPill from "../components/StatusPill";
 import SlashCommandBlock from "../components/SlashCommandBlock";
 import StatusBar from "../components/StatusBar";
@@ -87,16 +88,51 @@ function slashCommand(e: Entity): string {
   return `/${e.companion}-companion ${e.id}`;
 }
 
+// Grace period after entity creation before we trust the "no MCP traffic" signal.
+// Covers boot time for the user opening Claude Code + the initialize handshake.
+const MCP_GRACE_MS = 15_000;
+
 function PendingBody({ entity }: { entity: Entity }) {
   const note = entity.companion === "build"
     ? "Heads-up: start your Claude Code session inside the claudepanion repo, and make sure the plugin is installed (`claudepanion plugin install` in this repo, then restart Claude Code). Build scaffolds files into companions/ and skills/ relative to Claude's working directory."
     : undefined;
+  const mcp = useMcpStatus(true);
+  const ageMs = Date.now() - new Date(entity.createdAt).getTime();
+  const showStuck = !mcp.loading && mcp.firstRequestAt === null && ageMs > MCP_GRACE_MS;
   return (
     <>
       <SlashCommandBlock command={slashCommand(entity)} note={note} />
+      {showStuck && <McpStuckBanner />}
       <InputPanel entity={entity} />
       <LogsPanel logs={[]} waiting />
     </>
+  );
+}
+
+function McpStuckBanner() {
+  return (
+    <div role="alert" style={{
+      padding: "12px 16px",
+      background: "#fef3c7",
+      border: "1px solid #f59e0b",
+      borderRadius: 8,
+      fontSize: 13,
+      color: "#78350f",
+    }}>
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+        ⚠ claudepanion hasn't seen any MCP connection
+      </div>
+      <div>
+        No MCP client has contacted this server yet. Start a Claude Code session in your repo and the
+        connection should establish on its own. If it doesn't, try these in order:
+      </div>
+      <ol style={{ marginTop: 8, marginBottom: 0, paddingLeft: 20 }}>
+        <li>Run <code>/mcp</code> in your Claude Code session — confirm <code>claudepanion</code> is listed and not errored.</li>
+        <li>Re-install the plugin in the repo Claude Code is running from: <code>claudepanion plugin install</code>.</li>
+        <li>Rebuild the claudepanion checkout: <code>npm run build</code>.</li>
+        <li>Start a <strong>new</strong> Claude Code session (plugins load at session start, not mid-session).</li>
+      </ol>
+    </div>
   );
 }
 

--- a/src/client/primitives/CompanionForm.tsx
+++ b/src/client/primitives/CompanionForm.tsx
@@ -195,10 +195,17 @@ function FieldRow({ name, field, value, onChange, companionSlug, allValues }: Fi
   }
 
   if (isStringDatetime || ui.kind === "datetime") {
+    // datetime-local is timezone-naive ("YYYY-MM-DDTHH:MM"). Treat it as UTC so
+    // z.string().datetime() (which requires a Z-suffixed ISO 8601) accepts it.
+    const display = typeof value === "string" ? value.slice(0, 16) : "";
     return (
       <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         {labelEl}
-        <input type="datetime-local" value={typeof value === "string" ? value : ""} onChange={(e) => onChange(e.target.value)} />
+        <input
+          type="datetime-local"
+          value={display}
+          onChange={(e) => onChange(e.target.value ? `${e.target.value}:00Z` : undefined)}
+        />
       </label>
     );
   }

--- a/src/server/api-routes.ts
+++ b/src/server/api-routes.ts
@@ -8,6 +8,7 @@ import { spawn } from "node:child_process";
 import { validateCompanion } from "./reliability/validator.js";
 import type { RegisteredCompanion } from "./companion-registry.js";
 import { rewriteCompanionsIndex } from "./companions-index.js";
+import { getMcpStatus } from "./mcp-status.js";
 
 export interface ApiDeps {
   store: EntityStore;
@@ -31,6 +32,14 @@ export function mountApiRoutes(app: Express, { store, registry, reliability, del
 
   app.get("/api/companions", (_req: Request, res: Response) => {
     res.json(registry.list().map((c) => c.manifest));
+  });
+
+  app.get("/api/mcp/status", (_req: Request, res: Response) => {
+    const s = getMcpStatus();
+    res.json({
+      firstRequestAt: s.firstRequestAt ? new Date(s.firstRequestAt).toISOString() : null,
+      lastRequestAt: s.lastRequestAt ? new Date(s.lastRequestAt).toISOString() : null,
+    });
   });
 
   app.get("/api/companions/:name/preflight", (req: Request, res: Response) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,6 +11,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 import { dataPath, ensureClaudepanionDirs } from "./paths.js";
+import { bumpMcpStatus } from "./mcp-status.js";
 
 const PORT = Number(process.env.PORT ?? 3001);
 const repoRoot = process.cwd();
@@ -89,7 +90,10 @@ async function main() {
 
   const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => crypto.randomUUID() });
   await mcpServer.connect(transport);
-  app.all("/mcp", (req, res) => transport.handleRequest(req, res, req.body));
+  app.all("/mcp", (req, res) => {
+    bumpMcpStatus();
+    transport.handleRequest(req, res, req.body);
+  });
 
   app.get("/robots.txt", (_req, res) => {
     res.type("text/plain").send("User-agent: *\nDisallow: /\n");

--- a/src/server/mcp-status.ts
+++ b/src/server/mcp-status.ts
@@ -1,0 +1,31 @@
+/**
+ * Tracks whether an MCP client has ever talked to this server process.
+ *
+ * Bumped from the /mcp HTTP route on every incoming request — including the
+ * initial `initialize` handshake — so `firstRequestAt` flips from null to a
+ * timestamp the moment any MCP client connects, well before any tool call.
+ *
+ * The UI uses `firstRequestAt === null` as the authoritative "MCP has never
+ * connected" signal, replacing the earlier age-of-pending-entity heuristic.
+ */
+export interface McpStatus {
+  firstRequestAt: number | null;
+  lastRequestAt: number | null;
+}
+
+const state: McpStatus = { firstRequestAt: null, lastRequestAt: null };
+
+export function bumpMcpStatus(now: number = Date.now()): void {
+  if (state.firstRequestAt === null) state.firstRequestAt = now;
+  state.lastRequestAt = now;
+}
+
+export function getMcpStatus(): McpStatus {
+  return { firstRequestAt: state.firstRequestAt, lastRequestAt: state.lastRequestAt };
+}
+
+/** Test-only: clears observed state so each test starts fresh. */
+export function resetMcpStatus(): void {
+  state.firstRequestAt = null;
+  state.lastRequestAt = null;
+}

--- a/tests/client/CompanionForm.test.tsx
+++ b/tests/client/CompanionForm.test.tsx
@@ -38,6 +38,15 @@ describe("CompanionForm — datetime/number/checkbox/textarea", () => {
     expect(inp.type).toBe("datetime-local");
   });
 
+  it("submits datetime-local input as a Z-suffixed ISO string that satisfies z.string().datetime()", () => {
+    const schema = z.object({ when: z.string().datetime().describe("When") });
+    const onSubmit = vi.fn();
+    render(<CompanionForm schema={schema} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText(/when/i), { target: { value: "2026-05-10T14:30" } });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    expect(onSubmit).toHaveBeenCalledWith({ when: "2026-05-10T14:30:00Z" });
+  });
+
   it("renders number input for z.number()", () => {
     const schema = z.object({ count: z.number().describe("Count") });
     render(<CompanionForm schema={schema} onSubmit={() => {}} />);

--- a/tests/client/EntityDetail.test.tsx
+++ b/tests/client/EntityDetail.test.tsx
@@ -4,8 +4,11 @@ import { MemoryRouter, Routes, Route } from "react-router-dom";
 import EntityDetail from "../../src/client/pages/EntityDetail";
 import type { Entity } from "@shared/types";
 
-function mockFetch(entity: Partial<Entity>) {
+function mockFetch(entity: Partial<Entity>, mcpStatus: { firstRequestAt: string | null; lastRequestAt: string | null } = { firstRequestAt: null, lastRequestAt: null }) {
   vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url === "/api/mcp/status") {
+      return new Response(JSON.stringify(mcpStatus), { status: 200 });
+    }
     if (url.includes("/api/companions")) {
       return new Response(JSON.stringify([
         { name: "x", kind: "ui", displayName: "X", icon: "x", description: "x", contractVersion: "2", version: "0.1.0" },
@@ -65,6 +68,41 @@ describe("EntityDetail", () => {
     await vi.runOnlyPendingTimersAsync();
     await waitFor(() => expect(screen.getByText("completed")).toBeInTheDocument());
     expect(screen.getByText(/no markdown report/i)).toBeInTheDocument();
+  });
+
+  it("does not show the MCP-stuck banner when pending entity is fresh", async () => {
+    mockFetch({ status: "pending", createdAt: new Date().toISOString() });
+    renderAt("/c/x/x-1");
+    await vi.runOnlyPendingTimersAsync();
+    await waitFor(() => expect(screen.getByText("/x-companion x-1")).toBeInTheDocument());
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not show the MCP-stuck banner when MCP has connected (firstRequestAt set), even if entity is old", async () => {
+    const oldCreatedAt = new Date(Date.now() - 60_000).toISOString();
+    mockFetch(
+      { status: "pending", createdAt: oldCreatedAt },
+      { firstRequestAt: new Date(Date.now() - 30_000).toISOString(), lastRequestAt: new Date(Date.now() - 30_000).toISOString() }
+    );
+    renderAt("/c/x/x-1");
+    await vi.runOnlyPendingTimersAsync();
+    await waitFor(() => expect(screen.getByText("/x-companion x-1")).toBeInTheDocument());
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows the MCP-stuck banner when entity is past grace and MCP has never connected", async () => {
+    const oldCreatedAt = new Date(Date.now() - 30_000).toISOString();
+    mockFetch(
+      { status: "pending", createdAt: oldCreatedAt },
+      { firstRequestAt: null, lastRequestAt: null }
+    );
+    renderAt("/c/x/x-1");
+    await vi.runOnlyPendingTimersAsync();
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(/hasn't seen any MCP connection/i);
+    expect(banner).toHaveTextContent(/claudepanion plugin install/);
+    expect(banner).toHaveTextContent(/npm run build/);
   });
 
   it("renders error message and stack in error state", async () => {

--- a/tests/server/api-routes.test.ts
+++ b/tests/server/api-routes.test.ts
@@ -10,6 +10,7 @@ import { mountApiRoutes } from "../../src/server/api-routes";
 import type { Manifest } from "@shared/types";
 import { successResult } from "../../src/shared/types";
 import type { CompanionToolDefinition } from "../../src/shared/types";
+import { bumpMcpStatus, resetMcpStatus } from "../../src/server/mcp-status";
 
 const manifest = (name: string): Manifest => ({
   name,
@@ -42,6 +43,23 @@ describe("api routes", () => {
     const res = await request(app).get("/api/companions");
     expect(res.status).toBe(200);
     expect(res.body.map((m: Manifest) => m.name)).toEqual(["x"]);
+  });
+
+  it("GET /api/mcp/status returns nulls when no MCP traffic has been observed", async () => {
+    resetMcpStatus();
+    const res = await request(app).get("/api/mcp/status");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ firstRequestAt: null, lastRequestAt: null });
+  });
+
+  it("GET /api/mcp/status returns ISO timestamps after bumpMcpStatus is called", async () => {
+    resetMcpStatus();
+    bumpMcpStatus(1_700_000_000_000);
+    bumpMcpStatus(1_700_000_005_000);
+    const res = await request(app).get("/api/mcp/status");
+    expect(res.status).toBe(200);
+    expect(res.body.firstRequestAt).toBe(new Date(1_700_000_000_000).toISOString());
+    expect(res.body.lastRequestAt).toBe(new Date(1_700_000_005_000).toISOString());
   });
 
   it("POST /api/entities creates an entity", async () => {


### PR DESCRIPTION
## Summary

Three dogfood-driven fixes that surfaced during the second pass of the v2 contract on `main`:

1. **CompanionForm datetime fix.** Schema-driven forms with `z.string().datetime()` rejected every submit with *"Invalid input"* because `<input type="datetime-local">` produces a timezone-naive `YYYY-MM-DDTHH:MM` string and Zod requires Z-suffixed ISO 8601. The datetime branch now stores `${value}:00Z` and strips back via `slice(0, 16)` for display. **All companions with datetime fields were unsubmittable until this lands.**
2. **MCP precondition gate in `build-companion/SKILL.md`.** Step 0 now explicitly verifies the claudepanion MCP is reachable before any action. Anti-improvisation language ("STOP. Do not read files, run Bash, or improvise without the tooling"). Includes a 5-step troubleshooting ladder (`/mcp` → server check → `claudepanion plugin install` → `npm run build` → new session). Embedded pr-reviewer template carries the same gate so future scaffolds inherit it; Step 5's authored-files table now requires Step 0.
3. **UI awareness of MCP connection.** New `mcp-status` singleton bumps on every `/mcp` request (so the SDK's `initialize` handshake flips `firstRequestAt` from null the moment any MCP client connects). New `GET /api/mcp/status` endpoint, `useMcpStatus()` hook, and amber banner on the entity detail page. Banner fires when entity is pending past a 15s grace AND `firstRequestAt === null` — a real signal, not a fragile age heuristic. Replaces an earlier 30s-stuckness draft after dogfood found the threshold below the natural flow latency.

## Test Plan

- [x] 182 tests passing (was 176; six new — CompanionForm datetime round-trip, EntityDetail banner suppression when MCP connected / shown when not, api-routes status nulls + ISO after bump)
- [ ] Manual: hard-refresh, scaffold a companion with datetime fields, submit form succeeds
- [ ] Manual: restart `claudepanion serve`, create entity in UI, do NOT open Claude Code — banner appears after 15s
- [ ] Manual: with Claude Code session connected, submit entity — banner does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)