### PR TITLE
fix(plumbing): make claudepanion work in any cwd / for npm-install users

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claudepanion",
       "description": "Localhost companion host for Claude Code — build small web apps whose backend is Claude Code over MCP.",
-      "version": "0.3.0",
+      "version": "0.0.1",
       "source": "./",
       "author": {
         "name": "claudepanion"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claudepanion",
       "description": "Localhost companion host for Claude Code — build small web apps whose backend is Claude Code over MCP.",
-      "version": "0.0.1",
+      "version": "0.0.1-beta.0",
       "source": "./",
       "author": {
         "name": "claudepanion"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepanion",
   "description": "Localhost companion host for Claude Code — build small web apps whose backend is Claude Code over MCP.",
-  "version": "0.3.0",
+  "version": "0.0.1",
   "author": { "name": "claudepanion" },
   "license": "Apache-2.0",
   "keywords": ["mcp", "claude", "companion", "reference-architecture"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepanion",
   "description": "Localhost companion host for Claude Code — build small web apps whose backend is Claude Code over MCP.",
-  "version": "0.0.1",
+  "version": "0.0.1-beta.0",
   "author": { "name": "claudepanion" },
   "license": "Apache-2.0",
   "keywords": ["mcp", "claude", "companion", "reference-architecture"]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist-tag:
+        description: 'npm dist-tag (e.g. beta, next, latest). Pre-release versions (0.0.1-beta.0) should use "beta".'
+        required: true
+        default: 'beta'
+        type: string
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run check
+      - run: npm test
+      - run: npm run build
+      - name: Publish
+        run: |
+          TAG="${{ github.event.inputs.dist-tag || 'beta' }}"
+          echo "Publishing $(node -p "require('./package.json').version") with --tag $TAG"
+          npm publish --tag "$TAG"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist
 # per-machine Claude Code state — contains absolute paths + permission grants
 .claude/settings.local.json
 
+# npm auth (env-interpolated; never commit)
+.npmrc
+
 # runtime data — contents gitignored, directory kept via .gitkeep
 data/*
 !data/.gitkeep

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ claudepanion plugin install          # global: loads in every Claude Code sessio
 claudepanion plugin install --repo   # per-repo: writes to <repo>/.claude/settings.local.json
 ```
 
+This writes the Claude Code settings file, shells out to the `claude` CLI to activate the plugin (settings alone aren't enough — see [claude-code#32606](https://github.com/anthropics/claude-code/issues/32606)), and prints a self-check covering settings, plugin manifests, activation, and server reachability. If `claude` isn't on `PATH` it falls back to printing the exact commands to run by hand.
+
 Start the server:
 
 ```bash
@@ -48,7 +50,17 @@ git add . && git commit -m "initial"
 git push -u origin main
 ```
 
-On a new machine: `npm install -g claudepanion && git clone <your-repo> ~/.claudepanion && cd ~/.claudepanion && npm install`.
+On a new machine:
+
+```bash
+npm install -g claudepanion
+claudepanion init                                # creates ~/.claudepanion/ + symlinks + .claude-plugin/ + .mcp.json
+cd ~/.claudepanion
+git remote add origin git@github.com:you/my-claudepanion.git
+git pull origin main                             # layers your tracked companions/, skills/ on top
+```
+
+`init` is what restores the framework symlinks (`node_modules/claudepanion-host`, `companions/build`, `skills/build-companion`) — they're gitignored, so a plain `git clone` won't bring them back.
 
 ### Uninstall
 
@@ -124,7 +136,8 @@ The full contract reference is at [`docs/scaffold-spec.md`](./docs/scaffold-spec
 
 - [Concept](./docs/concept.md) — thesis, owned tensions, near-term unresolved questions
 - [Companion contract reference](./docs/scaffold-spec.md) — the authoritative spec for the v2 companion shape
-- [Latest design spec](./docs/superpowers/specs/2026-05-09-scaffold-consistency-design.md) — the v2 redesign that produced the current contract (schema-driven forms, markdown artifacts, scaffold CLI)
+- [v2 design spec](./docs/superpowers/specs/2026-05-09-scaffold-consistency-design.md) — the v2 redesign that produced the current contract (schema-driven forms, markdown artifacts, scaffold CLI)
+- [Plugin plumbing design](./docs/superpowers/specs/2026-05-17-plugin-plumbing-design.md) — how `init` lays down `.claude-plugin/` + a port-aware `.mcp.json`, and how `plugin install` activates via the `claude` CLI so claudepanion loads in any cwd
 - [Implementation plans](./docs/superpowers/plans/) — historical plan docs in build order
 - [Troubleshooting](./docs/troubleshooting.md) — common issues
 

--- a/README.md
+++ b/README.md
@@ -126,12 +126,6 @@ Reference companion: `~/.claudepanion/companions/build/` (the only one shipped b
 
 The full contract reference is at [`docs/scaffold-spec.md`](./docs/scaffold-spec.md). The design that produced the current (v2) contract is captured in [`docs/superpowers/specs/2026-05-09-scaffold-consistency-design.md`](./docs/superpowers/specs/2026-05-09-scaffold-consistency-design.md).
 
-## Philosophy
-
-- **Reference architecture first, framework second.** Fork it, strip Build, adapt to your needs. Or keep Build and use it to grow your own company of companions.
-- **Claude Code is the backend.** claudepanion doesn't call an LLM API. Everything intelligent happens in Claude Code sessions connected via MCP.
-- **Localhost only, single user.** No auth, no multi-tenancy, no marketplace. This is developer tooling.
-
 ## Documentation
 
 - [Concept](./docs/concept.md) — thesis, owned tensions, near-term unresolved questions

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -94,8 +94,49 @@ async function pluginInstall() {
 
   const result = await runPluginInstall(opts);
   if (!result.ok) die(`✗ ${result.error}`);
-  console.log(`\n✓  Plugin installed (${result.settingsPath})`);
-  console.log("   Start a new Claude Code session for the plugin to load.");
+  console.log(`\n✓  Settings written (${result.settingsPath})`);
+
+  // settings.json alone does NOT activate a directory-marketplace plugin
+  // (Claude Code bug #32606), so drive activation via the `claude` CLI and
+  // self-report the whole chain. A degraded result is actionable, not fatal.
+  const { activateAndReport } = await import(join(pkgRoot, "dist/src/cli/plugin-install.js"));
+  const report = await activateAndReport({ home });
+  const mark = (b) => (b ? "✓" : "✗");
+
+  console.log(`\nPlugin plumbing self-check:`);
+  console.log(`  ${mark(true)} settings.json written`);
+  const manifests =
+    existsSync(join(home, ".claude-plugin/plugin.json")) && existsSync(join(home, ".mcp.json"));
+  console.log(
+    `  ${mark(manifests)} .claude-plugin/ + .mcp.json present` +
+      (manifests ? "" : " — run 'claudepanion init'")
+  );
+  if (report.activation.activated) {
+    console.log(`  ${mark(true)} plugin activated via the claude CLI`);
+  } else {
+    console.log(`  ${mark(false)} plugin NOT activated (${report.activation.reason})`);
+  }
+  if (report.server.reachable) {
+    console.log(
+      `  ${mark(true)} server reachable at :${report.server.port}` +
+        (report.server.mcpOk ? " (MCP up)" : " (MCP status unknown)")
+    );
+  } else {
+    console.log(`  ${mark(false)} ${report.server.detail ?? "server not reachable"}`);
+  }
+
+  console.log(
+    `\nNext: restart your Claude Code session, then run /<name>-companion <entity-id>.`
+  );
+
+  if (!report.activation.activated) {
+    console.log(`\n⚠  ACTION REQUIRED — finish activation manually:`);
+    for (const c of report.activation.commands) console.log(`     ${c}`);
+    console.log(
+      `   (or inside a Claude Code session: '/plugin marketplace add ${home}'` +
+        ` then '/plugin install claudepanion@local')`
+    );
+  }
 }
 
 async function pluginUninstall() {

--- a/docs/superpowers/specs/2026-05-17-plugin-plumbing-design.md
+++ b/docs/superpowers/specs/2026-05-17-plugin-plumbing-design.md
@@ -116,7 +116,9 @@ Neither generated file is added to `~/.claudepanion/.gitignore`; they are durabl
 
 ## Version Reconciliation
 
-Framework `package.json` is `0.2.0` but the framework `.claude-plugin/plugin.json` is `0.3.0`. Single source of truth = `package.json`. **This PR bumps `package.json` `0.2.0` → `0.3.0`** so it agrees with the existing `.claude-plugin/plugin.json` and the npm-publish plan, and the generated manifests derive their version from `package.json`. No hardcoded version remains to drift. The bump is in-scope because a generated manifest is incoherent without a correct authoritative version.
+Framework `package.json` is `0.2.0` but the framework `.claude-plugin/plugin.json` is `0.3.0`. Single source of truth = `package.json`; the generated manifests derive their version from it, so no hardcoded version remains to drift. Reconciling all sources is in-scope because a generated manifest is incoherent without a correct authoritative version.
+
+> **Superseded for first publish (2026-05-17):** rather than `0.3.0`, all version sources (`package.json`, framework `.claude-plugin/{plugin,marketplace}.json`) are set to **`0.0.1`** — nothing has been published to npm yet, so the first public release starts at `0.0.1`. The single-source-of-truth principle is unchanged; only the chosen number differs.
 
 ## Data Flow (end-to-end, npm-install user)
 

--- a/docs/superpowers/specs/2026-05-17-plugin-plumbing-design.md
+++ b/docs/superpowers/specs/2026-05-17-plugin-plumbing-design.md
@@ -1,0 +1,175 @@
+# Plugin Plumbing — Make claudepanion Work in Any Directory / For npm-install Users
+
+**Status:** Approved design (2026-05-17). Next step: implementation plan via `superpowers:writing-plans`.
+
+**Branch:** `fix/plugin-plumbing` (dedicated PR off `main`, after PR #24 / facelift merged as `48c2ba9`).
+
+---
+
+## Goal
+
+A user who runs `npm install -g claudepanion` (no repo clone), then `claudepanion init` → `claudepanion serve` → `claudepanion plugin install`, can open Claude Code in **any working directory** and have both the companion slash commands **and** the MCP connection work. Today they only work when Claude Code's cwd is inside the framework checkout.
+
+## Root Cause (confirmed)
+
+- The `claudepanion` MCP server is declared **only** in the framework repo's project-scoped `./.mcp.json`. Claude Code loads a project `.mcp.json` only when cwd is inside that repo, so the MCP connection is unavailable everywhere else.
+- `claudepanion init` lays down **no plugin plumbing**: `~/.claudepanion/` has neither `.claude-plugin/` (the marketplace/plugin manifest) nor a plugin-root `.mcp.json`. The `init.ts` SYMLINKS table covers only `companions/build`, `skills/build-companion`, `node_modules/claudepanion-host`.
+- The current machine's `~/.claudepanion/.claude-plugin/` exists only because it was hand-created during a prior debugging session; a fresh npm-install user has nothing.
+
+## Authoritative Claude Code Behavior (docs + cited issues)
+
+These facts (from official docs and cited CC GitHub issues) constrain the design and **supersede** the earlier idea of "reconcile `known_marketplaces.json`":
+
+1. A Claude Code plugin can bundle an MCP server via a **plugin-root `.mcp.json`** (same shape as a project `.mcp.json`). When the plugin is genuinely *installed*, that server connects regardless of cwd. `type: "http"` and `"streamable-http"` are accepted aliases.
+2. `settings.json` `extraKnownMarketplaces` + `enabledPlugins` **alone is not sufficient** for non-interactive activation — CC bug [#32606](https://github.com/anthropics/claude-code/issues/32606) (auto-install prompt never fires; `installed_plugins.json` never updated → skills/commands don't load). Related: [#17832](https://github.com/anthropics/claude-code/issues/17832).
+3. **Never hand-write** `~/.claude/plugins/known_marketplaces.json` (CC owns it; rewrites it one-way from `settings.json` at startup — hand-edits are overwritten) **or `installed_plugins.json`** (internal, undocumented, unsupported).
+4. The supported non-interactive activation mechanism is the **`claude` CLI**: `claude plugin marketplace add <dir>` + `claude plugin install <name>@<marketplace>`. A marketplace path change is reconciled with `claude plugin marketplace update <name>` — **not** `marketplace remove` + `add`, which uninstalls plugins.
+5. Plugin-provided `.mcp.json` loads only once the plugin is genuinely **installed** (not merely `enabledPlugins: true`). Therefore plugin activation is the single linchpin for **both** slash commands and MCP.
+
+## Architecture (Approach B — dedicated modules)
+
+Two new focused modules; `init`/`serve`/`plugin install` become thin callers. The init↔serve port agreement is structurally guaranteed by a single shared writer; the `claude` shell-out is isolated in one unit.
+
+### `src/server/mcp-config.ts`
+
+```ts
+export function writeMcpConfig(home: string, port: number): { written: boolean; path: string };
+```
+
+- Computes the canonical `~/.claudepanion/.mcp.json` content for `port`, reads any existing file, writes **only if different** (`written` reflects whether a write happened). Create-or-update; never throws on absence.
+- Single source of truth for the `.mcp.json` shape. Lives under `src/server/` because `boot.ts` is its hot-path caller and it expresses the server's MCP contract; `init.ts` imports it too.
+
+### `src/cli/claude-plugin.ts`
+
+```ts
+export function ensureClaudePluginManifest(home: string, version: string): { path: string };
+
+export type ActivateResult =
+  | { activated: true; ranCommands: string[] }
+  | { activated: false; reason: "claude-not-found" | "command-failed"; commands: string[]; detail?: string };
+
+export function activatePlugin(opts: {
+  home: string;
+  spawn?: typeof import("node:child_process").spawn; // injectable for tests
+  log?: (line: string) => void;
+}): Promise<ActivateResult>;
+```
+
+- `ensureClaudePluginManifest` generates `~/.claudepanion/.claude-plugin/{plugin.json,marketplace.json}` idempotently. If `.claude-plugin` exists as a **symlink** (a prior approach / hand-fix), it is unlinked and replaced with a real directory before writing. Existing files are overwritten in place.
+- `activatePlugin` runs the `claude` CLI shell-out. Never throws on `claude` absence — returns a structured result; the caller decides messaging.
+
+### Thin callers
+
+- **`src/cli/init.ts` (`runInit`)** — after the existing symlink/regenerate/tsc steps, calls `ensureClaudePluginManifest(home, version)` and `writeMcpConfig(home, 3001)`. Both added to `filesCreated`. `version` is read from the framework `package.json` (see Version Reconciliation). Generation runs *after* the existing "refuse to clobber non-claudepanion content" validate gate, preserving that protection.
+- **`src/server/boot.ts`** — calls `writeMcpConfig(home, effectivePort)` exactly once before `app.listen`, so `.mcp.json` always matches the actually-bound port. `effectivePort` is the value `boot.ts` already computes (`opts.port ?? Number(process.env.PORT ?? 3001)`).
+- **`src/cli/plugin-install.ts` (`runPluginInstall`)** — keeps its current `settings.json` writes unchanged, then calls `activatePlugin(...)`, then the `/mcp` self-report.
+
+## Generated Artifacts
+
+`~/.claudepanion/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "claudepanion",
+  "description": "Localhost companion host for Claude Code — build small web apps whose backend is Claude Code over MCP.",
+  "version": "<framework package.json version>",
+  "author": { "name": "claudepanion" },
+  "license": "Apache-2.0",
+  "keywords": ["mcp", "claude", "companion", "reference-architecture"]
+}
+```
+
+`~/.claudepanion/.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "local",
+  "description": "Local marketplace for claudepanion",
+  "owner": { "name": "claudepanion" },
+  "plugins": [
+    {
+      "name": "claudepanion",
+      "description": "Localhost companion host for Claude Code — build small web apps whose backend is Claude Code over MCP.",
+      "version": "<framework package.json version>",
+      "source": "./",
+      "author": { "name": "claudepanion" }
+    }
+  ]
+}
+```
+
+`source: "./"` means the plugin root is `~/.claudepanion` — unambiguous because this is a real file, not a symlink (the reason `.claude-plugin/` is generated, not symlinked). The plugin's skills/companions are already present there via the existing `init` symlinks.
+
+`~/.claudepanion/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "claudepanion": { "type": "http", "url": "http://localhost:<port>/mcp" }
+  }
+}
+```
+
+A concrete port, not `${...}` interpolation — Claude Code's environment at session start has no `PORT`, which is exactly why `init` writes `3001` and `serve` corrects it.
+
+Neither generated file is added to `~/.claudepanion/.gitignore`; they are durable config and the home may not be a git repo.
+
+## Version Reconciliation
+
+Framework `package.json` is `0.2.0` but the framework `.claude-plugin/plugin.json` is `0.3.0`. Single source of truth = `package.json`. **This PR bumps `package.json` `0.2.0` → `0.3.0`** so it agrees with the existing `.claude-plugin/plugin.json` and the npm-publish plan, and the generated manifests derive their version from `package.json`. No hardcoded version remains to drift. The bump is in-scope because a generated manifest is incoherent without a correct authoritative version.
+
+## Data Flow (end-to-end, npm-install user)
+
+1. `npm i -g claudepanion` → `claudepanion init`: home dirs + symlinks (as today) **+ `.claude-plugin/{plugin.json,marketplace.json}` generated + `.mcp.json` written at default `:3001`**.
+2. `claudepanion serve`: boots, binds effective port → **`writeMcpConfig(home, effectivePort)` rewrites `.mcp.json` iff the port differs** → server listening.
+3. `claudepanion plugin install`: writes `settings.json` (unchanged) → **`activatePlugin`: `claude plugin marketplace add ~/.claudepanion` (or `marketplace update local` if already known) + `claude plugin install claudepanion@local`** → `/mcp` self-report → prints next-step + restart note.
+4. User opens Claude Code in **any directory** → plugin installed/active → skills + slash commands load → plugin-provided `.mcp.json` connects the `claudepanion` MCP server globally.
+
+## Activation Flow (`runPluginInstall`)
+
+1. **`settings.json` (unchanged):** `enabledPlugins["claudepanion@local"]=true`, `extraKnownMarketplaces.local={source:{source:"directory",path:home}}`, `additionalDirectories` includes `home`. Idempotent. If `local` previously pointed elsewhere (old framework-checkout setup), this write updates the path.
+2. **`activatePlugin`:**
+   - Detect `claude` on PATH (`claude --version`). Absent → `{ activated:false, reason:"claude-not-found", commands:[…] }`; no throw.
+   - **Marketplace (idempotent, path-change-safe, never remove):** `claude plugin marketplace add <home>`. If it reports already-known, treat as success **and** run `claude plugin marketplace update local` to refresh from the (possibly changed) path. Never `marketplace remove` (uninstalls plugins).
+   - **Install:** `claude plugin install claudepanion@local`. Already-installed → success.
+   - Returns the structured `ActivateResult`.
+3. **`/mcp` self-report:** parse the port from `~/.claudepanion/.mcp.json` (serve's source of truth), then `GET http://localhost:<port>/api/health` for liveness and `GET http://localhost:<port>/api/mcp/status` for the richer MCP-up signal. Print a concise ✓/✗ checklist: settings written · `.claude-plugin/` + `.mcp.json` present · `claude` activation result · server reachable at `<port>` · **next step: "Restart your Claude Code session, then run `/<name>-companion <id>`."**
+4. **Fallback & exit code:** if `claude` is absent or a command fails, print the exact manual commands (`claude plugin marketplace add ~/.claudepanion`, `claude plugin install claudepanion@local`, plus the in-session `/plugin` equivalents) + the restart note. `plugin install` **exits 0 even when degraded** (prints a prominent `ACTION REQUIRED` block); only true hard errors (settings.json unwritable, home missing) exit non-zero, keeping it script-composable. Re-running is always safe.
+
+## Error Handling / Edge Cases
+
+- `.claude-plugin` exists as a symlink → unlink, create real dir, write files. Existing files → overwrite in place (idempotent regenerate).
+- Generation runs after `runInit`'s "refuse to clobber non-claudepanion content" validate gate — protection preserved.
+- `serve` with `.mcp.json` missing/deleted → `writeMcpConfig` create-or-updates; never errors on absence.
+- `plugin install` self-probe when server not running → `.mcp.json` still parses (init wrote it); `GET /api/health` fails → that line reports ✗ "server not reachable at `<port>` — run `claudepanion serve`"; plugin activation result reported independently; still exit 0.
+- Hard errors only (settings.json unwritable, home missing) → non-zero exit, preserving current behavior.
+- Multi-server / multi-home concurrency remains a pre-existing single-home assumption — a noted limitation, not addressed here.
+
+## Testing Strategy
+
+Claude Code itself cannot be driven in automated tests, so coverage is on file outputs, the shell-out seam, and a documented manual acceptance run.
+
+- **`tests/server/mcp-config.test.ts`** — correct `.mcp.json` shape per port; idempotent (`written:false` when unchanged); rewrites on port change; creates when absent.
+- **`tests/cli/claude-plugin.test.ts`** — `ensureClaudePluginManifest`: manifests parse, version from injected value, idempotent, `.claude-plugin` symlink → real-dir replacement. `activatePlugin` with an injected fake `spawn`: asserts the exact `claude` argv sequence (`marketplace add` → `marketplace update local` on already-known → `install`); `claude`-absent returns the structured fallback with the command list; command-failure surfaces `reason:"command-failed"`.
+- **`tests/cli/init.test.ts`** (additions) — after `runInit`, `~/.claudepanion/.claude-plugin/{plugin.json,marketplace.json}` and `.mcp.json` exist, parse, version matches framework `package.json`, `.mcp.json` port = 3001, all listed in `filesCreated`.
+- **`tests/cli/plugin-install.test.ts`** (additions) — settings.json writes unchanged; `activatePlugin` invoked via injected spawn; self-report reflects probe result; degraded path → exit 0, hard error → non-zero.
+- **`boot`→`writeMcpConfig` seam** — a focused unit asserting a non-default `PORT` yields the right `.mcp.json` (no full server boot).
+
+### Manual Acceptance Checklist (documented; run once per release)
+
+1. Fresh `HOME` (or a clean `~/.claudepanion`), `npm i -g claudepanion` (or `npm link`).
+2. `claudepanion init` → assert `~/.claudepanion/.claude-plugin/{plugin.json,marketplace.json}` + `.mcp.json` (port 3001) exist and parse.
+3. `claudepanion serve` → assert `.mcp.json` still 3001.
+4. `claudepanion plugin install` → assert it shells out (or prints the fallback) and the ✓/✗ self-report is accurate.
+5. Open Claude Code **in an unrelated directory**, restart the session → `/build-companion` resolves **and** a built companion's MCP tools connect.
+6. Repeat step 3 as `PORT=4000 claudepanion serve` → assert `.mcp.json` updates to `:4000`.
+
+## Explicitly Out of Scope (YAGNI)
+
+- No `claudepanion doctor` command.
+- Never write `known_marketplaces.json` / `installed_plugins.json` (authoritatively contraindicated).
+- No `mcp-http.ts` / MCP protocol changes.
+- One shell-out attempt + fallback (no retry/daemon logic).
+- Do not fix upstream CC bug #32606 — work around it.
+- The `additionalDirectories` grant stays (Issue #23 — MCP-mediated writes — is a separate thread).
+- Version reconciliation limited to bumping `package.json` → `0.3.0`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudepanion",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/src/host/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudepanion",
-  "version": "0.0.1",
+  "version": "0.0.1-beta.0",
   "description": "Localhost companion host for Claude Code — build small web apps whose backend is Claude Code over MCP.",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,30 @@
 {
   "name": "claudepanion",
-  "version": "0.3.0",
+  "version": "0.0.1",
+  "description": "Localhost companion host for Claude Code — build small web apps whose backend is Claude Code over MCP.",
   "license": "Apache-2.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sean1588/claudepanion.git"
+  },
+  "homepage": "https://github.com/sean1588/claudepanion#readme",
+  "bugs": {
+    "url": "https://github.com/sean1588/claudepanion/issues"
+  },
+  "keywords": [
+    "claude",
+    "claude-code",
+    "mcp",
+    "companion",
+    "reference-architecture"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/src/host/index.js",
   "types": "./dist/src/host/index.d.ts",
   "exports": {
@@ -30,6 +52,7 @@
     "dev:client": "vite",
     "dev:tsc": "tsc -p tsconfig.json --watch --preserveWatchOutput",
     "build": "tsc -p tsconfig.json && vite build",
+    "prepublishOnly": "npm run build",
     "start": "node dist/src/server/index.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/cli/claude-plugin.ts
+++ b/src/cli/claude-plugin.ts
@@ -1,0 +1,163 @@
+import { existsSync, lstatSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+
+const PLUGIN_DESCRIPTION =
+  "Localhost companion host for Claude Code — build small web apps whose backend is Claude Code over MCP.";
+
+/**
+ * Generates `~/.claudepanion/.claude-plugin/{plugin.json,marketplace.json}`.
+ *
+ * Generated (not symlinked) on purpose: `marketplace.json`'s `source: "./"` is
+ * resolved by Claude Code relative to the plugin root, and if `.claude-plugin/`
+ * were a symlink to the framework checkout, the plugin root would resolve there
+ * — re-introducing the exact "only works inside the repo" bug. A real directory
+ * at `~/.claudepanion/.claude-plugin/` makes the plugin root unambiguous.
+ *
+ * `version` comes from the framework `package.json` (single source of truth, no
+ * hardcoded version to drift). Idempotent: deterministic content, rewritten in
+ * place each call. A pre-existing `.claude-plugin` *symlink* (an old approach or
+ * a hand-fix) is unlinked and replaced with a real directory first.
+ */
+export function ensureClaudePluginManifest(home: string, version: string): { path: string } {
+  const dir = join(home, ".claude-plugin");
+
+  try {
+    const st = lstatSync(dir);
+    if (st.isSymbolicLink()) unlinkSync(dir);
+  } catch {
+    // doesn't exist — fine.
+  }
+  mkdirSync(dir, { recursive: true });
+
+  const plugin = {
+    name: "claudepanion",
+    description: PLUGIN_DESCRIPTION,
+    version,
+    author: { name: "claudepanion" },
+    license: "Apache-2.0",
+    keywords: ["mcp", "claude", "companion", "reference-architecture"],
+  };
+  const marketplace = {
+    name: "local",
+    description: "Local marketplace for claudepanion",
+    owner: { name: "claudepanion" },
+    plugins: [
+      {
+        name: "claudepanion",
+        description: PLUGIN_DESCRIPTION,
+        version,
+        source: "./",
+        author: { name: "claudepanion" },
+      },
+    ],
+  };
+
+  writeFileSync(join(dir, "plugin.json"), JSON.stringify(plugin, null, 2) + "\n");
+  writeFileSync(join(dir, "marketplace.json"), JSON.stringify(marketplace, null, 2) + "\n");
+  return { path: dir };
+}
+
+export interface ClaudeResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Injectable seam (mirrors api-routes' `deleteCompanionFiles` convention). */
+export type RunClaude = (args: string[]) => Promise<ClaudeResult>;
+
+/** Default `runClaude` — spawns the real `claude` CLI. ENOENT (not on PATH)
+ *  resolves to code 127 rather than rejecting, so callers branch uniformly. */
+const defaultRunClaude: RunClaude = (args) =>
+  new Promise((resolve) => {
+    const proc = spawn("claude", args, { shell: false });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout?.on("data", (d) => { stdout += d.toString(); });
+    proc.stderr?.on("data", (d) => { stderr += d.toString(); });
+    proc.on("error", (err) => resolve({ code: 127, stdout, stderr: stderr || err.message }));
+    proc.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+
+export type ActivateResult =
+  | { activated: true; ranCommands: string[] }
+  | { activated: false; reason: "claude-not-found" | "command-failed"; commands: string[]; detail?: string };
+
+const FALLBACK_COMMANDS = (home: string) => [
+  `claude plugin marketplace add ${home}`,
+  `claude plugin install claudepanion@local`,
+];
+
+function looksAlreadyKnown(r: ClaudeResult): boolean {
+  return /already|exists|known/i.test(`${r.stdout} ${r.stderr}`);
+}
+
+/**
+ * Activates the claudepanion plugin via the `claude` CLI.
+ *
+ * `settings.json` `extraKnownMarketplaces`+`enabledPlugins` alone does NOT
+ * activate a directory-marketplace plugin (Claude Code bug #32606), so the
+ * supported non-interactive path is `claude plugin marketplace add` +
+ * `claude plugin install`. Marketplace re-registration uses `marketplace
+ * update` (never `remove`+`add`, which uninstalls plugins). Never throws on a
+ * missing `claude` — returns a structured result so the caller can print a
+ * manual fallback.
+ */
+export async function activatePlugin(opts: {
+  home: string;
+  runClaude?: RunClaude;
+  log?: (line: string) => void;
+}): Promise<ActivateResult> {
+  const run = opts.runClaude ?? defaultRunClaude;
+  const home = opts.home;
+  const ranCommands: string[] = [];
+  const record = (args: string[]) => ranCommands.push(`claude ${args.join(" ")}`);
+
+  // Probe: is the claude CLI available?
+  const probe = await run(["--version"]);
+  if (probe.code !== 0) {
+    return { activated: false, reason: "claude-not-found", commands: FALLBACK_COMMANDS(home) };
+  }
+
+  // Marketplace: add; if already known, refresh via `update` (never remove).
+  const addArgs = ["plugin", "marketplace", "add", home];
+  const add = await run(addArgs);
+  if (add.code === 0) {
+    record(addArgs);
+  } else if (looksAlreadyKnown(add)) {
+    const updateArgs = ["plugin", "marketplace", "update", "local"];
+    const update = await run(updateArgs);
+    if (update.code !== 0) {
+      return {
+        activated: false,
+        reason: "command-failed",
+        commands: FALLBACK_COMMANDS(home),
+        detail: `marketplace update failed: ${update.stderr || update.stdout}`.trim(),
+      };
+    }
+    record(updateArgs);
+  } else {
+    return {
+      activated: false,
+      reason: "command-failed",
+      commands: FALLBACK_COMMANDS(home),
+      detail: `marketplace add failed: ${add.stderr || add.stdout}`.trim(),
+    };
+  }
+
+  // Install (already-installed is success).
+  const installArgs = ["plugin", "install", "claudepanion@local"];
+  const install = await run(installArgs);
+  if (install.code !== 0 && !looksAlreadyKnown(install)) {
+    return {
+      activated: false,
+      reason: "command-failed",
+      commands: FALLBACK_COMMANDS(home),
+      detail: `plugin install failed: ${install.stderr || install.stdout}`.trim(),
+    };
+  }
+  record(installArgs);
+
+  return { activated: true, ranCommands };
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -9,6 +9,8 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
+import { ensureClaudePluginManifest } from "./claude-plugin.js";
+import { writeMcpConfig, DEFAULT_MCP_PORT } from "../server/mcp-config.js";
 
 export interface RunInitOptions {
   home: string;
@@ -189,6 +191,22 @@ export async function runInit(opts: RunInitOptions): Promise<RunInitResult> {
       error: `tsc failed: ${tscResult.stderr.slice(0, 500)}`,
     };
   }
+
+  // Plugin plumbing: generate the plugin-root manifest + MCP config so the
+  // companion slash commands AND the MCP connection work in ANY cwd (not just
+  // inside the framework checkout). Version is the framework's single source
+  // of truth; `serve` later corrects the .mcp.json port if it differs.
+  let frameworkVersion = "0.0.0";
+  try {
+    frameworkVersion =
+      JSON.parse(readFileSync(join(opts.frameworkRoot, "package.json"), "utf-8")).version ?? "0.0.0";
+  } catch {
+    // unreadable framework package.json — fall back to a placeholder version;
+    // the manifest is still structurally valid and CC only needs it to parse.
+  }
+  ensureClaudePluginManifest(opts.home, frameworkVersion);
+  writeMcpConfig(opts.home, DEFAULT_MCP_PORT);
+  filesCreated.push(".claude-plugin/plugin.json", ".claude-plugin/marketplace.json", ".mcp.json");
 
   return { ok: true, symlinks, filesCreated };
 }

--- a/src/cli/plugin-install.ts
+++ b/src/cli/plugin-install.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+import { activatePlugin, type ActivateResult, type RunClaude } from "./claude-plugin.js";
 
 export interface PluginInstallOptions {
   scope: "global" | "repo";
@@ -71,6 +72,90 @@ export async function runPluginInstall(opts: PluginInstallOptions): Promise<Plug
 
   writeJson(settingsPath, settings);
   return { ok: true, settingsPath };
+}
+
+export type ProbeFn = (url: string) => Promise<{ ok: boolean; status?: number }>;
+
+export interface ServerProbe {
+  /** Port parsed from ~/.claudepanion/.mcp.json, or null if missing/unparseable. */
+  port: number | null;
+  reachable: boolean;
+  /** /api/mcp/status responded ok (only meaningful when reachable). */
+  mcpOk?: boolean;
+  detail?: string;
+}
+
+export interface ActivateReport {
+  activation: ActivateResult;
+  server: ServerProbe;
+}
+
+const defaultProbe: ProbeFn = async (url) => {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 1500);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal });
+    return { ok: res.ok, status: res.status };
+  } catch {
+    return { ok: false };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+function parseMcpPort(home: string): number | null {
+  try {
+    const j = JSON.parse(readFileSync(join(home, ".mcp.json"), "utf-8"));
+    const url: string = j?.mcpServers?.claudepanion?.url ?? "";
+    const m = url.match(/:(\d+)\/mcp\b/);
+    return m ? Number(m[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Activates the plugin via the `claude` CLI and probes the running server, so
+ * `claudepanion plugin install` can self-report whether the chain actually
+ * works (settings.json alone is insufficient — Claude Code bug #32606).
+ *
+ * Separate from {@link runPluginInstall} (which only writes settings.json, and
+ * must stay side-effect-light for its tests) so this — the part that shells out
+ * and hits the network — is unit-tested only with injected fakes and never runs
+ * the real `claude` CLI / `fetch` in the suite.
+ */
+export async function activateAndReport(opts: {
+  home: string;
+  runClaude?: RunClaude;
+  probe?: ProbeFn;
+  log?: (line: string) => void;
+}): Promise<ActivateReport> {
+  const activation = await activatePlugin({
+    home: opts.home,
+    runClaude: opts.runClaude,
+    log: opts.log,
+  });
+
+  const port = parseMcpPort(opts.home);
+  const probe = opts.probe ?? defaultProbe;
+  let server: ServerProbe;
+  if (port == null) {
+    server = { port: null, reachable: false, detail: ".mcp.json missing or unparseable" };
+  } else {
+    const health = await probe(`http://localhost:${port}/api/health`);
+    if (!health.ok) {
+      server = {
+        port,
+        reachable: false,
+        detail: `server not reachable at :${port} — run 'claudepanion serve'`,
+      };
+    } else {
+      const mcp = await probe(`http://localhost:${port}/api/mcp/status`);
+      server = { port, reachable: true, mcpOk: mcp.ok };
+    }
+  }
+
+  return { activation, server };
 }
 
 export async function runPluginUninstall(opts: { scope: "global" | "repo"; userHome?: string; repoRoot?: string }): Promise<PluginInstallResult> {

--- a/src/server/boot.ts
+++ b/src/server/boot.ts
@@ -14,6 +14,7 @@ import { buildMcpServer } from "./mcp.js";
 import { createMcpHttp } from "./mcp-http.js";
 import { createWatcher, type ReliabilitySnapshot, type MountFailure } from "./reliability/watcher.js";
 import { dataPath, ensureClaudepanionDirs } from "./paths.js";
+import { writeMcpConfig, DEFAULT_MCP_PORT } from "./mcp-config.js";
 
 export interface BootOptions {
   /** Pre-resolved list of companions to register. Caller is responsible for loading these from user-local dist. */
@@ -54,11 +55,21 @@ function checkTscHealth(repoRoot: string): void {
   }
 }
 
+/** The effective port: explicit option > `PORT` env > shared default. Pure so
+ *  the `.mcp.json` port-correction seam is unit-testable without booting. */
+export function resolveServerPort(opts: { port?: number }): number {
+  return opts.port ?? Number(process.env.PORT ?? DEFAULT_MCP_PORT);
+}
+
 export async function bootServer(opts: BootOptions): Promise<void> {
-  const port = opts.port ?? Number(process.env.PORT ?? 3001);
+  const port = resolveServerPort(opts);
   const repoRoot = opts.cwd ?? process.cwd();
 
   ensureClaudepanionDirs();
+
+  // Keep ~/.claudepanion/.mcp.json pointing at the actually-bound port (init
+  // wrote the default). Idempotent — only rewrites if the port changed.
+  writeMcpConfig(repoRoot, port);
   const store = createEntityStore(dataPath());
   const registry = createRegistry(opts.companions);
   const snapshots = new Map<string, ReliabilitySnapshot>();

--- a/src/server/mcp-config.ts
+++ b/src/server/mcp-config.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Default server port. `init` writes this into `.mcp.json`; `serve` corrects
+ *  it to the effective port. Shared so the two can't disagree. */
+export const DEFAULT_MCP_PORT = 3001;
+
+/**
+ * Writes `~/.claudepanion/.mcp.json` — the plugin-root MCP config Claude Code
+ * loads (in any cwd) once the claudepanion plugin is installed.
+ *
+ * Single source of truth for the file's shape. Both `init` (default port 3001)
+ * and `boot` (the actually-bound port) call this, so the two can never disagree
+ * about the URL. Idempotent: the file is rewritten only when its content would
+ * change, so calling it on every `serve` is cheap and touch-free.
+ *
+ * A concrete port is baked in, not `${...}` interpolation — Claude Code's
+ * environment at session start has no `PORT`, which is why `init` writes 3001
+ * and `serve` corrects it.
+ */
+export function writeMcpConfig(home: string, port: number): { written: boolean; path: string } {
+  const path = join(home, ".mcp.json");
+  const desired =
+    JSON.stringify(
+      {
+        mcpServers: {
+          claudepanion: { type: "http", url: `http://localhost:${port}/mcp` },
+        },
+      },
+      null,
+      2,
+    ) + "\n";
+
+  const existing = existsSync(path) ? readFileSync(path, "utf-8") : null;
+  if (existing === desired) return { written: false, path };
+
+  writeFileSync(path, desired);
+  return { written: true, path };
+}

--- a/tests/cli/claude-plugin.test.ts
+++ b/tests/cli/claude-plugin.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  lstatSync,
+  readFileSync,
+  mkdirSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureClaudePluginManifest, activatePlugin } from "../../src/cli/claude-plugin.js";
+
+let home: string;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "cp-claudeplugin-"));
+});
+afterEach(() => {
+  try { rmSync(home, { recursive: true, force: true }); } catch {}
+});
+
+describe("ensureClaudePluginManifest", () => {
+  it("generates parseable plugin.json + marketplace.json with the given version", () => {
+    const r = ensureClaudePluginManifest(home, "0.3.0");
+    expect(r.path).toBe(join(home, ".claude-plugin"));
+    const plugin = JSON.parse(readFileSync(join(home, ".claude-plugin/plugin.json"), "utf-8"));
+    const mkt = JSON.parse(readFileSync(join(home, ".claude-plugin/marketplace.json"), "utf-8"));
+    expect(plugin.name).toBe("claudepanion");
+    expect(plugin.version).toBe("0.3.0");
+    expect(mkt.name).toBe("local");
+    expect(mkt.plugins[0].name).toBe("claudepanion");
+    expect(mkt.plugins[0].version).toBe("0.3.0");
+    expect(mkt.plugins[0].source).toBe("./");
+  });
+
+  it("is idempotent — re-running keeps valid manifests", () => {
+    ensureClaudePluginManifest(home, "0.3.0");
+    expect(() => ensureClaudePluginManifest(home, "0.3.0")).not.toThrow();
+    const plugin = JSON.parse(readFileSync(join(home, ".claude-plugin/plugin.json"), "utf-8"));
+    expect(plugin.version).toBe("0.3.0");
+  });
+
+  it("replaces a pre-existing .claude-plugin symlink with a real directory", () => {
+    const otherDir = mkdtempSync(join(tmpdir(), "cp-other-"));
+    mkdirSync(join(otherDir, "x"));
+    symlinkSync(otherDir, join(home, ".claude-plugin"));
+    expect(lstatSync(join(home, ".claude-plugin")).isSymbolicLink()).toBe(true);
+
+    ensureClaudePluginManifest(home, "0.3.0");
+
+    expect(lstatSync(join(home, ".claude-plugin")).isSymbolicLink()).toBe(false);
+    expect(lstatSync(join(home, ".claude-plugin")).isDirectory()).toBe(true);
+    expect(existsSync(join(home, ".claude-plugin/plugin.json"))).toBe(true);
+    // the symlink target is untouched
+    expect(existsSync(join(otherDir, "x"))).toBe(true);
+    rmSync(otherDir, { recursive: true, force: true });
+  });
+});
+
+/** Scripts runClaude responses keyed by the first two args (e.g. "plugin marketplace"). */
+function fakeRunClaude(script: (args: string[]) => { code: number; stdout?: string; stderr?: string }) {
+  const calls: string[][] = [];
+  const fn = async (args: string[]) => {
+    calls.push(args);
+    const r = script(args);
+    return { code: r.code, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+  };
+  return Object.assign(fn, { calls });
+}
+
+describe("activatePlugin", () => {
+  it("activates: marketplace add + install when claude is present and clean", async () => {
+    const run = fakeRunClaude((args) => {
+      if (args[0] === "--version") return { code: 0, stdout: "2.1.143" };
+      return { code: 0 };
+    });
+    const r = await activatePlugin({ home, runClaude: run });
+    expect(r.activated).toBe(true);
+    if (r.activated) {
+      expect(r.ranCommands.some((c) => c.includes("marketplace add"))).toBe(true);
+      expect(r.ranCommands.some((c) => c.includes("install claudepanion@local"))).toBe(true);
+    }
+  });
+
+  it("returns claude-not-found (no throw) when the claude CLI is absent", async () => {
+    const run = fakeRunClaude((args) => {
+      if (args[0] === "--version") return { code: 127, stderr: "command not found" };
+      return { code: 0 };
+    });
+    const r = await activatePlugin({ home, runClaude: run });
+    expect(r.activated).toBe(false);
+    if (!r.activated) {
+      expect(r.reason).toBe("claude-not-found");
+      expect(r.commands.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("treats an already-known marketplace as success and runs marketplace update", async () => {
+    const run = fakeRunClaude((args) => {
+      if (args[0] === "--version") return { code: 0, stdout: "2.1.143" };
+      if (args.join(" ") === `plugin marketplace add ${home}`)
+        return { code: 1, stderr: "marketplace 'local' already exists" };
+      return { code: 0 };
+    });
+    const r = await activatePlugin({ home, runClaude: run });
+    expect(r.activated).toBe(true);
+    expect(run.calls.some((c) => c.join(" ") === "plugin marketplace update local")).toBe(true);
+  });
+
+  it("returns command-failed when marketplace add fails for a non-already reason", async () => {
+    const run = fakeRunClaude((args) => {
+      if (args[0] === "--version") return { code: 0, stdout: "2.1.143" };
+      if (args[1] === "marketplace") return { code: 1, stderr: "permission denied" };
+      return { code: 0 };
+    });
+    const r = await activatePlugin({ home, runClaude: run });
+    expect(r.activated).toBe(false);
+    if (!r.activated) expect(r.reason).toBe("command-failed");
+  });
+});

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -17,7 +17,10 @@ afterEach(() => {
   try { rmSync(home, { recursive: true, force: true }); } catch {}
 });
 
-describe("runInit — fresh install", () => {
+// Each test spawns a real `tsc` compile (runInit); under full-suite parallel
+// CPU contention that exceeds vitest's 5s default. Mirror the explicit
+// long-timeout convention used by end-to-end.test.ts.
+describe("runInit — fresh install", { timeout: 60_000 }, () => {
   it("creates package.json with name 'claudepanion-home'", async () => {
     const result = await runInit({ home, frameworkRoot });
     expect(result.ok).toBe(true);
@@ -74,7 +77,47 @@ describe("runInit — fresh install", () => {
   });
 });
 
-describe("runInit — idempotent", () => {
+describe("runInit — plugin plumbing", { timeout: 60_000 }, () => {
+  it("generates .claude-plugin/ + .mcp.json so the plugin works in any cwd", async () => {
+    const result = await runInit({ home, frameworkRoot });
+    expect(result.ok).toBe(true);
+
+    const fwVersion = JSON.parse(
+      readFileSync(join(frameworkRoot, "package.json"), "utf-8"),
+    ).version;
+
+    // .claude-plugin/ is a REAL dir (not a symlink) so marketplace.json's
+    // source:"./" resolves to ~/.claudepanion, not the framework checkout.
+    const cpDir = join(home, ".claude-plugin");
+    expect(lstatSync(cpDir).isDirectory()).toBe(true);
+    expect(lstatSync(cpDir).isSymbolicLink()).toBe(false);
+
+    const plugin = JSON.parse(readFileSync(join(cpDir, "plugin.json"), "utf-8"));
+    expect(plugin.name).toBe("claudepanion");
+    expect(plugin.version).toBe(fwVersion);
+
+    const mkt = JSON.parse(readFileSync(join(cpDir, "marketplace.json"), "utf-8"));
+    expect(mkt.name).toBe("local");
+    expect(mkt.plugins[0].version).toBe(fwVersion);
+    expect(mkt.plugins[0].source).toBe("./");
+
+    const mcp = JSON.parse(readFileSync(join(home, ".mcp.json"), "utf-8"));
+    expect(mcp.mcpServers.claudepanion.type).toBe("http");
+    expect(mcp.mcpServers.claudepanion.url).toBe("http://localhost:3001/mcp");
+
+    if (result.ok) {
+      expect(result.filesCreated).toEqual(
+        expect.arrayContaining([
+          ".claude-plugin/plugin.json",
+          ".claude-plugin/marketplace.json",
+          ".mcp.json",
+        ]),
+      );
+    }
+  });
+});
+
+describe("runInit — idempotent", { timeout: 60_000 }, () => {
   it("running twice does not error and refreshes symlinks", async () => {
     await runInit({ home, frameworkRoot });
     const result2 = await runInit({ home, frameworkRoot });
@@ -96,7 +139,7 @@ describe("runInit — idempotent", () => {
   });
 });
 
-describe("runInit — clobber refusal", () => {
+describe("runInit — clobber refusal", { timeout: 60_000 }, () => {
   it("returns error if existing package.json has a non-claudepanion-home name", async () => {
     const result = await runInit({ home, frameworkRoot });
     expect(result.ok).toBe(true);

--- a/tests/cli/plugin-install.test.ts
+++ b/tests/cli/plugin-install.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, readFileSync, existsSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runPluginInstall, runPluginUninstall } from "../../src/cli/plugin-install";
+import { runPluginInstall, runPluginUninstall, activateAndReport } from "../../src/cli/plugin-install";
 
 let userHome: string;       // simulates $HOME
 let repoRoot: string;       // simulates a git repo with a .git/
@@ -58,6 +58,69 @@ describe("plugin install — --repo", () => {
     const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
     expect(settings.enabledPlugins["claudepanion@local"]).toBe(true);
     expect(settings.extraKnownMarketplaces.local.source.path).toBe(join(userHome, ".claudepanion"));
+  });
+});
+
+describe("activateAndReport", () => {
+  let home: string;
+  beforeEach(() => { home = join(userHome, ".claudepanion"); });
+
+  const allOk = async (args: string[]) =>
+    args[0] === "--version"
+      ? { code: 0, stdout: "2.1.143", stderr: "" }
+      : { code: 0, stdout: "", stderr: "" };
+
+  const writeMcp = (port: number) =>
+    writeFileSync(
+      join(home, ".mcp.json"),
+      JSON.stringify({ mcpServers: { claudepanion: { type: "http", url: `http://localhost:${port}/mcp` } } }),
+    );
+
+  it("activates and reports a reachable server", async () => {
+    writeMcp(3001);
+    const r = await activateAndReport({
+      home,
+      runClaude: allOk,
+      probe: async () => ({ ok: true, status: 200 }),
+    });
+    expect(r.activation.activated).toBe(true);
+    expect(r.server.port).toBe(3001);
+    expect(r.server.reachable).toBe(true);
+    expect(r.server.mcpOk).toBe(true);
+  });
+
+  it("reports claude-not-found without throwing, still probes the server", async () => {
+    writeMcp(3001);
+    const r = await activateAndReport({
+      home,
+      runClaude: async (args) =>
+        args[0] === "--version" ? { code: 127, stdout: "", stderr: "not found" } : { code: 0, stdout: "", stderr: "" },
+      probe: async () => ({ ok: true }),
+    });
+    expect(r.activation.activated).toBe(false);
+    if (!r.activation.activated) expect(r.activation.reason).toBe("claude-not-found");
+    expect(r.server.reachable).toBe(true);
+  });
+
+  it("reports an unreachable server with serve guidance", async () => {
+    writeMcp(3001);
+    const r = await activateAndReport({
+      home,
+      runClaude: allOk,
+      probe: async () => ({ ok: false }),
+    });
+    expect(r.server.reachable).toBe(false);
+    expect(r.server.detail).toMatch(/claudepanion serve/);
+  });
+
+  it("handles a missing .mcp.json (port null, not reachable)", async () => {
+    const r = await activateAndReport({
+      home,
+      runClaude: allOk,
+      probe: async () => ({ ok: true }),
+    });
+    expect(r.server.port).toBeNull();
+    expect(r.server.reachable).toBe(false);
   });
 });
 

--- a/tests/server/boot-port.test.ts
+++ b/tests/server/boot-port.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveServerPort } from "../../src/server/boot.js";
+import { writeMcpConfig, DEFAULT_MCP_PORT } from "../../src/server/mcp-config.js";
+
+describe("resolveServerPort", () => {
+  let savedPort: string | undefined;
+  beforeEach(() => { savedPort = process.env.PORT; delete process.env.PORT; });
+  afterEach(() => {
+    if (savedPort === undefined) delete process.env.PORT;
+    else process.env.PORT = savedPort;
+  });
+
+  it("prefers an explicit option", () => {
+    expect(resolveServerPort({ port: 5555 })).toBe(5555);
+  });
+
+  it("falls back to the PORT env var", () => {
+    process.env.PORT = "4000";
+    expect(resolveServerPort({})).toBe(4000);
+  });
+
+  it("falls back to the shared default", () => {
+    expect(resolveServerPort({})).toBe(DEFAULT_MCP_PORT);
+  });
+});
+
+describe("boot → writeMcpConfig seam", () => {
+  let home: string;
+  let savedPort: string | undefined;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "cp-bootport-"));
+    savedPort = process.env.PORT;
+  });
+  afterEach(() => {
+    try { rmSync(home, { recursive: true, force: true }); } catch {}
+    if (savedPort === undefined) delete process.env.PORT;
+    else process.env.PORT = savedPort;
+  });
+
+  it("a non-default PORT yields a .mcp.json with that port (no server boot)", () => {
+    process.env.PORT = "4000";
+    const port = resolveServerPort({});
+    writeMcpConfig(home, port);
+    const mcp = JSON.parse(readFileSync(join(home, ".mcp.json"), "utf-8"));
+    expect(mcp.mcpServers.claudepanion.url).toBe("http://localhost:4000/mcp");
+  });
+});

--- a/tests/server/mcp-config.test.ts
+++ b/tests/server/mcp-config.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeMcpConfig } from "../../src/server/mcp-config.js";
+
+let home: string;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "cp-mcpcfg-"));
+});
+afterEach(() => {
+  try { rmSync(home, { recursive: true, force: true }); } catch {}
+});
+
+describe("writeMcpConfig", () => {
+  it("creates .mcp.json with the canonical http shape for the given port", () => {
+    const r = writeMcpConfig(home, 3001);
+    expect(r.written).toBe(true);
+    expect(r.path).toBe(join(home, ".mcp.json"));
+    expect(existsSync(r.path)).toBe(true);
+    const json = JSON.parse(readFileSync(r.path, "utf-8"));
+    expect(json.mcpServers.claudepanion.type).toBe("http");
+    expect(json.mcpServers.claudepanion.url).toBe("http://localhost:3001/mcp");
+  });
+
+  it("is idempotent — second call with the same port does not rewrite", () => {
+    writeMcpConfig(home, 3001);
+    const before = readFileSync(join(home, ".mcp.json"), "utf-8");
+    const r = writeMcpConfig(home, 3001);
+    expect(r.written).toBe(false);
+    expect(readFileSync(join(home, ".mcp.json"), "utf-8")).toBe(before);
+  });
+
+  it("rewrites when the port changes", () => {
+    writeMcpConfig(home, 3001);
+    const r = writeMcpConfig(home, 4000);
+    expect(r.written).toBe(true);
+    const json = JSON.parse(readFileSync(join(home, ".mcp.json"), "utf-8"));
+    expect(json.mcpServers.claudepanion.url).toBe("http://localhost:4000/mcp");
+  });
+
+  it("creates the file when absent without throwing", () => {
+    expect(existsSync(join(home, ".mcp.json"))).toBe(false);
+    expect(() => writeMcpConfig(home, 3001)).not.toThrow();
+    expect(existsSync(join(home, ".mcp.json"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the core Option-B blocker: claudepanion only worked when Claude Code's cwd was inside the framework checkout. `claudepanion init` laid down **no** plugin plumbing — `~/.claudepanion/` had neither `.claude-plugin/` nor a plugin-root `.mcp.json`, so for an `npm install -g` user the slash commands AND the MCP connection were unavailable everywhere else.

- **`init`** generates `~/.claudepanion/.claude-plugin/{plugin.json,marketplace.json}` (a **real dir**, not a symlink — so `marketplace.json`'s `source:"./"` resolves to the home, not the framework) + a port-aware `.mcp.json` (default `:3001`).
- **`serve`** corrects `.mcp.json` to the actually-bound port via a shared `writeMcpConfig` (init & serve can't disagree).
- **`plugin install`** drives activation through the `claude` CLI (`settings.json` alone is insufficient — CC bug [#32606](https://github.com/anthropics/claude-code/issues/32606)), idempotent and path-change-safe (`marketplace update`, never `remove`), with a printed manual fallback and an `/api/health` + `/api/mcp/status` self-report (exit 0 when degraded).
- `package.json` `0.2.0 → 0.3.0` as the single version source for the generated manifests.

New modules: `src/server/mcp-config.ts`, `src/cli/claude-plugin.ts`. `init`/`boot`/`plugin-install` are thin callers; `bin/cli.js` renders the self-check. Design spec: `docs/superpowers/specs/2026-05-17-plugin-plumbing-design.md`.

Two deviations from the spec, faithful to its intent: the injectable seam is a higher-level `runClaude` (matches the `deleteCompanionFiles` convention) not raw `spawn`; `activateAndReport` is split from `runPluginInstall` so the settings-only tests never shell out to the real `claude`.

## Test Plan

- [x] 302 automated tests pass, `tsc --noEmit` clean (20 new across mcp-config / claude-plugin / boot-port / init / plugin-install)
- [ ] **Manual acceptance** (automated tests can't drive Claude Code): fresh/clean home → `claudepanion init` (assert `.claude-plugin/*` + `.mcp.json`@3001) → `claudepanion serve` → `claudepanion plugin install` (watch the ✓/✗ self-check) → open Claude Code **in an unrelated directory**, restart session → `/build-companion` resolves **and** a built companion's MCP tools connect
- [ ] `PORT=4000 claudepanion serve` updates `.mcp.json` to `:4000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)