### PR TITLE
Structured form for Build's new-companion authoring

### DIFF
--- a/companions/build/examples.ts
+++ b/companions/build/examples.ts
@@ -1,27 +1,50 @@
-export interface BuildExample {
+export interface BuildFormField {
+  name: string;
+  required: boolean;
+  description: string;
+}
+
+export interface BuildToolSpec {
+  /** Tool name, snake_case (e.g. `fetch_url`). */
+  name: string;
+  /** What the tool does + when to use it. */
+  description: string;
+  /** Free-text description of arguments (name, type, required/optional, default). */
+  args: string;
+}
+
+interface BuildExampleBase {
   slug: string;
-  kind: "ui" | "tool";
   displayName: string;
   icon: string;
   /** Short subtitle shown on the chip card and as a tooltip. */
   description: string;
-  /**
-   * Rich, structured template that prefills the Build form's textarea when
-   * the user clicks the chip. Includes the artifact shape and form fields
-   * Build should scaffold — gives Build enough to one-shot a useful companion
-   * instead of iterating on missing detail. Falls back to `description` if
-   * absent.
-   */
-  prompt?: string;
+  /** What the companion is for / what it produces. */
+  goal: string;
+  /** Read-only / auth / defaults / anything Build should know. */
+  behavior: string;
 }
 
-// Chips are form-text-prefill sugar only. Each chip below is a description known
-// to produce a working companion when Build runs it (see scaffold-spec §16h
-// and the dogfood runs in PR #13). Each one names a distinct external system,
-// captures WHERE/WHICH (not "paste your text here"), and defaults to read-only.
-//
-// Chips do NOT drive any per-companion skill-template branching — Build authors
-// the skill body from scratch every time per §16d.
+export interface BuildUiExample extends BuildExampleBase {
+  kind: "ui";
+  /** Structured form fields the scaffolded companion should expose. */
+  formFields: BuildFormField[];
+  /** Free-form markdown sketch of the artifact's sections/shape. */
+  artifactTemplate: string;
+}
+
+export interface BuildToolExample extends BuildExampleBase {
+  kind: "tool";
+  /** MCP tools the scaffolded companion should expose. */
+  tools: BuildToolSpec[];
+}
+
+export type BuildExample = BuildUiExample | BuildToolExample;
+
+// Chips prefill the structured Build form. Each one names a distinct external
+// system, captures WHERE/WHICH (not "paste your text here"), and defaults to
+// read-only. Chips do NOT drive any per-companion skill-template branching —
+// Build authors the skill body from scratch every time per scaffold-spec §16d.
 export const buildExamples: BuildExample[] = [
   {
     slug: "github-pr-reviewer",
@@ -30,23 +53,21 @@ export const buildExamples: BuildExample[] = [
     icon: "🔎",
     description:
       "Review a GitHub pull request: fetch the PR metadata, the unified diff, and existing review comments. Flag risky diffs (auth changes, swallowed errors, missing tests) and suggest review questions for the author. Read-only — do not post anything back to GitHub.",
-    prompt: `Review a GitHub pull request: fetch the diff, existing review comments, and PR metadata, then produce a structured code-review report. Read-only — do not post comments back to GitHub.
-
-The artifact follows a fixed template the reviewer must fill in:
-
-1. **Verdict** — 1-2 sentence overall take (e.g. "Solid refactor with two blocking concerns" or "Ship it").
+    goal: `Review a GitHub pull request: fetch the diff, existing review comments, and PR metadata, then produce a structured code-review report.`,
+    formFields: [
+      { name: "Repo", required: true, description: "owner/name format, e.g. sean1588/claudepanion" },
+      { name: "PR number", required: true, description: "integer" },
+      { name: "Review focus", required: false, description: "free-text bias like \"security\" or \"performance\" to weight the analysis" },
+    ],
+    artifactTemplate: `1. **Verdict** — 1-2 sentence overall take (e.g. "Solid refactor with two blocking concerns" or "Ship it").
 2. **Risks** — bullet list of anything that could break in production (auth, data loss, concurrency, missing tests, swallowed errors). Each risk cites file:line.
 3. **Address before merge** — actionable items, grouped by severity:
    - **Major** — must fix before merge (correctness bugs, security, breaking changes)
    - **Minor** — should fix but not blocking (clarity, naming, missing edge case)
    - **Nits** — optional polish (typos, style preferences)
    Each item cites file:line and names what to change.
-4. **Questions for the author** — clarifying questions where intent is unclear.
-
-Form fields:
-- Repo (required) — owner/name format, e.g. sean1588/claudepanion
-- PR number (required) — integer
-- Review focus (optional) — free-text bias like "security" or "performance" to weight the analysis`,
+4. **Questions for the author** — clarifying questions where intent is unclear.`,
+    behavior: `Read-only — do not post comments back to GitHub. Uses a GitHub token from the local environment (e.g. \`gh auth token\` or GITHUB_TOKEN).`,
   },
   {
     slug: "cloudwatch-investigator",
@@ -55,26 +76,24 @@ Form fields:
     icon: "📊",
     description:
       "Investigate AWS CloudWatch logs over a time window — either driven by a triggered alarm or as a general log dive. Uses local AWS credentials (~/.aws/credentials profile). Read-only.",
-    prompt: `Investigate AWS CloudWatch logs to diagnose an issue. The use case is intentionally broader than just alarms — it should work equally well for "this alarm tripped, why?" and for "I think something's wrong, let me dig into the logs." Query the relevant log groups over the given time window, find error patterns, correlate with alarm transitions (if an alarm was provided), and produce a structured investigation report. Uses local AWS credentials from ~/.aws/credentials. Read-only — do not modify alarms, logs, dashboards, or any AWS resources.
-
-The artifact follows a fixed template the investigator must fill in:
-
-1. **Headline finding** — 1-2 sentence top-level conclusion, with a confidence tag (**High** / **Medium** / **Low**) and the evidence that drove it.
+    goal: `Investigate AWS CloudWatch logs to diagnose an issue. The use case is intentionally broader than just alarms — it should work equally well for "this alarm tripped, why?" and for "I think something's wrong, let me dig into the logs." Query the relevant log groups over the given time window, find error patterns, correlate with alarm transitions (if an alarm was provided), and produce a structured investigation report.`,
+    formFields: [
+      { name: "AWS profile", required: true, description: "name from ~/.aws/credentials, e.g. \"default\" or \"prod-readonly\". A plain dropdown listing profiles detected in the user's local credentials file is ideal; fall back to a text input if profile enumeration isn't trivial." },
+      { name: "Region", required: true, description: "**searchable dropdown prepopulated with the full list of AWS public regions** (us-east-1, us-east-2, us-west-1, us-west-2, eu-west-1, eu-west-2, eu-central-1, ap-northeast-1, ap-southeast-1, ap-southeast-2, sa-east-1, etc. — there are roughly 30, hardcode them since the list changes rarely). Default to the profile's configured region if available." },
+      { name: "Log groups", required: true, description: "**searchable multi-select dropdown that lazily loads ALL CloudWatch log groups in the selected region from AWS** when the user opens it (calls DescribeLogGroups; paginates if needed). The user can pick one or more. This list depends on Region — when the Region changes, the cached list must be invalidated and re-fetched on next open. If Region isn't selected yet, the dropdown should be disabled with a \"Select a region first\" hint." },
+      { name: "Time window start", required: true, description: "ISO-8601 timestamp, e.g. 2026-05-22T03:00:00Z. Default to \"1 hour before now\" on form open." },
+      { name: "Time window end", required: true, description: "ISO-8601 timestamp. Default to \"now.\"" },
+      { name: "Alarm name", required: false, description: "exact CloudWatch alarm name when the investigation is alarm-driven; leave blank for a general log dive. When provided, the investigation should include alarm state transitions in the timeline section." },
+      { name: "Filter pattern", required: false, description: "CloudWatch Logs Insights filter string for power users (e.g. `fields @timestamp, @message | filter @message like /ERROR/`). If absent, default to a broad error-pattern scan across the selected log groups." },
+    ],
+    artifactTemplate: `1. **Headline finding** — 1-2 sentence top-level conclusion, with a confidence tag (**High** / **Medium** / **Low**) and the evidence that drove it.
 2. **Error patterns observed** — bullet list of distinct error signatures in the logs. For each: pattern, occurrence count, first-seen / last-seen timestamps, a representative log line, and (where context allows) the likely subsystem.
 3. **Timeline** — chronological bullet list of key events in the window: deploys, error spikes, latency shifts, and alarm state transitions if an alarm was provided. Each entry has a timestamp.
 4. **Recommended next checks** — grouped by priority:
    - **Major** — checks that would confirm or refute the top hypothesis (specific metrics to query, dashboards to open, code paths to inspect, queries to re-run with broader filters)
    - **Minor** — supporting investigations worth doing if the major checks come back inconclusive
-5. **Related signals worth watching** — bullets covering related alarms, metrics, or log groups that may be relevant. Link to the CloudWatch resource where possible.
-
-Form fields:
-- **AWS profile** (required) — name from ~/.aws/credentials, e.g. "default" or "prod-readonly". A plain dropdown listing profiles detected in the user's local credentials file is ideal; fall back to a text input if profile enumeration isn't trivial.
-- **Region** (required) — **searchable dropdown prepopulated with the full list of AWS public regions** (us-east-1, us-east-2, us-west-1, us-west-2, eu-west-1, eu-west-2, eu-central-1, ap-northeast-1, ap-southeast-1, ap-southeast-2, sa-east-1, etc. — there are roughly 30, hardcode them since the list changes rarely). Default to the profile's configured region if available.
-- **Log groups** (required) — **searchable multi-select dropdown that lazily loads ALL CloudWatch log groups in the selected region from AWS** when the user opens it (calls DescribeLogGroups; paginates if needed). The user can pick one or more. This list depends on Region — when the Region changes, the cached list must be invalidated and re-fetched on next open. If Region isn't selected yet, the dropdown should be disabled with a "Select a region first" hint.
-- **Time window start** (required) — ISO-8601 timestamp, e.g. 2026-05-22T03:00:00Z. Default to "1 hour before now" on form open.
-- **Time window end** (required) — ISO-8601 timestamp. Default to "now."
-- **Alarm name** (optional) — exact CloudWatch alarm name when the investigation is alarm-driven; leave blank for a general log dive. When provided, the investigation should include alarm state transitions in the timeline section.
-- **Filter pattern** (optional) — CloudWatch Logs Insights filter string for power users (e.g. \`fields @timestamp, @message | filter @message like /ERROR/\`). If absent, default to a broad error-pattern scan across the selected log groups.
+5. **Related signals worth watching** — bullets covering related alarms, metrics, or log groups that may be relevant. Link to the CloudWatch resource where possible.`,
+    behavior: `Uses local AWS credentials from ~/.aws/credentials. Read-only — do not modify alarms, logs, dashboards, or any AWS resources.
 
 Notes for Build:
 - The Region list is essentially static — hardcode it as a constant rather than calling AWS.
@@ -88,23 +107,83 @@ Notes for Build:
     icon: "📋",
     description:
       "Triage Linear issues for a team: list stale tickets (untouched for over 30 days), summarize each one, and suggest priority changes. Read-only — do not update issues.",
-    prompt: `Triage a Linear team's backlog: pull the open issues, identify stale or misprioritized tickets, and produce a structured grooming report the team can work through synchronously. Read-only — do not modify any issues, statuses, or priorities.
-
-The artifact follows a fixed template the groomer must fill in:
-
-1. **Backlog health summary** — 2-3 sentences on the overall shape (total open, % stale, oldest untouched ticket, biggest category of staleness).
+    goal: `Triage a Linear team's backlog: pull the open issues, identify stale or misprioritized tickets, and produce a structured grooming report the team can work through synchronously.`,
+    formFields: [
+      { name: "Linear API key", required: true, description: "personal API key from Linear settings" },
+      { name: "Team key", required: true, description: "short team identifier, e.g. \"ENG\" or \"DESIGN\"" },
+      { name: "Staleness threshold in days", required: false, description: "how old \"stale\" means (default 30)" },
+      { name: "Label filter", required: false, description: "only consider tickets with this label, e.g. \"bug\" or \"tech-debt\"" },
+      { name: "Max tickets to review", required: false, description: "cap for very large backlogs (default 50)" },
+    ],
+    artifactTemplate: `1. **Backlog health summary** — 2-3 sentences on the overall shape (total open, % stale, oldest untouched ticket, biggest category of staleness).
 2. **Tickets by recommended action** — grouped buckets, each with the ticket title, identifier (e.g. ENG-1234), age since last update, and a one-sentence justification:
    - **Archive** — should be closed without action (obsolete, duplicate, won't-do)
    - **Reprioritize** — priority no longer matches reality (escalate or de-escalate)
    - **Needs grooming** — has insufficient detail to estimate or assign; requires owner follow-up
    - **Keep as-is** — valid and well-scoped but happens to be old; no action required
-3. **Suggested follow-ups for the team** — bullet list of cross-cutting observations (e.g. "5 tickets all mention the same flaky test — worth a dedicated chunk of time").
-
-Form fields:
-- Linear API key (required) — personal API key from Linear settings
-- Team key (required) — short team identifier, e.g. "ENG" or "DESIGN"
-- Staleness threshold in days (optional, default 30) — how old "stale" means
-- Label filter (optional) — only consider tickets with this label, e.g. "bug" or "tech-debt"
-- Max tickets to review (optional, default 50) — cap for very large backlogs`,
+3. **Suggested follow-ups for the team** — bullet list of cross-cutting observations (e.g. "5 tickets all mention the same flaky test — worth a dedicated chunk of time").`,
+    behavior: `Read-only — do not modify any issues, statuses, or priorities.`,
   },
 ];
+
+export type BuildPromptParts =
+  | {
+      kind: "ui";
+      goal: string;
+      formFields: BuildFormField[];
+      artifactTemplate: string;
+      behavior: string;
+    }
+  | {
+      kind: "tool";
+      goal: string;
+      tools: BuildToolSpec[];
+      behavior: string;
+    };
+
+/**
+ * Produces a Build-friendly description string from the structured form parts.
+ * Mirrors the shape of the original hand-authored chip prompts so the build
+ * skill doesn't need to know the form is now structured.
+ */
+export function serializeBuildPrompt(parts: BuildPromptParts): string {
+  const sections: string[] = [];
+
+  const goal = parts.goal.trim();
+  if (goal) sections.push(goal);
+
+  if (parts.kind === "ui") {
+    const tpl = parts.artifactTemplate.trim();
+    if (tpl) {
+      sections.push(`The artifact follows a fixed template the companion must fill in:\n\n${tpl}`);
+    }
+    const fields = parts.formFields.filter((f) => f.name.trim().length > 0);
+    if (fields.length > 0) {
+      const lines = fields.map((f) => {
+        const tag = f.required ? "required" : "optional";
+        const desc = f.description.trim();
+        return desc ? `- **${f.name.trim()}** (${tag}) — ${desc}` : `- **${f.name.trim()}** (${tag})`;
+      });
+      sections.push(`Form fields:\n${lines.join("\n")}`);
+    }
+  } else {
+    const tools = parts.tools.filter((t) => t.name.trim().length > 0);
+    if (tools.length > 0) {
+      const blocks = tools.map((t) => {
+        const lines: string[] = [`- **${t.name.trim()}** — ${t.description.trim() || "(no description)"}`];
+        const args = t.args.trim();
+        if (args) {
+          const indented = args.split("\n").map((l) => `  ${l}`).join("\n");
+          lines.push(`  Args:\n${indented}`);
+        }
+        return lines.join("\n");
+      });
+      sections.push(`Tools to expose:\n${blocks.join("\n")}`);
+    }
+  }
+
+  const behavior = parts.behavior.trim();
+  if (behavior) sections.push(`Behavior & constraints:\n${behavior}`);
+
+  return sections.join("\n\n");
+}

--- a/companions/build/form.tsx
+++ b/companions/build/form.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react";
 import { useSearchParams, useNavigate, Link } from "react-router-dom";
 import type { BuildInput } from "./types";
-import { buildExamples } from "./examples";
+import { buildExamples, serializeBuildPrompt, type BuildFormField, type BuildToolSpec } from "./examples";
 import { useCompanions } from "../../src/client/hooks/useCompanions";
 
 interface Props {
   onSubmit: (input: BuildInput) => void | Promise<void>;
 }
+
+const EMPTY_FIELD: BuildFormField = { name: "", required: true, description: "" };
+const EMPTY_TOOL: BuildToolSpec = { name: "", description: "", args: "" };
 
 export default function BuildForm({ onSubmit }: Props) {
   const [params] = useSearchParams();
@@ -24,13 +27,30 @@ export default function BuildForm({ onSubmit }: Props) {
 
   const [name, setName] = useState(asideExample?.slug ?? "");
   const [kind, setKind] = useState<"ui" | "tool">(asideExample?.kind ?? "ui");
-  const [description, setDescription] = useState(asideExample?.prompt ?? asideExample?.description ?? "");
+  const [goal, setGoal] = useState(asideExample?.goal ?? "");
+  const [formFields, setFormFields] = useState<BuildFormField[]>(
+    asideExample?.kind === "ui" ? asideExample.formFields.map((f) => ({ ...f })) : [{ ...EMPTY_FIELD }]
+  );
+  const [artifactTemplate, setArtifactTemplate] = useState(
+    asideExample?.kind === "ui" ? asideExample.artifactTemplate : ""
+  );
+  const [tools, setTools] = useState<BuildToolSpec[]>(
+    asideExample?.kind === "tool" ? asideExample.tools.map((t) => ({ ...t })) : [{ ...EMPTY_TOOL }]
+  );
+  const [behavior, setBehavior] = useState(asideExample?.behavior ?? "");
 
   useEffect(() => {
     if (asideExample) {
       setName(asideExample.slug);
       setKind(asideExample.kind);
-      setDescription(asideExample.prompt ?? asideExample.description);
+      setGoal(asideExample.goal);
+      setBehavior(asideExample.behavior);
+      if (asideExample.kind === "ui") {
+        setFormFields(asideExample.formFields.map((f) => ({ ...f })));
+        setArtifactTemplate(asideExample.artifactTemplate);
+      } else {
+        setTools(asideExample.tools.map((t) => ({ ...t })));
+      }
     }
   }, [exampleSlug]);
 
@@ -38,11 +58,27 @@ export default function BuildForm({ onSubmit }: Props) {
   const trimmedName = name.trim();
   const nameTaken = trimmedName.length > 0 && companions.some((c) => c.name === trimmedName);
 
+  const updateField = (i: number, patch: Partial<BuildFormField>) => {
+    setFormFields((prev) => prev.map((f, idx) => (idx === i ? { ...f, ...patch } : f)));
+  };
+  const addField = () => setFormFields((prev) => [...prev, { ...EMPTY_FIELD }]);
+  const removeField = (i: number) => setFormFields((prev) => prev.filter((_, idx) => idx !== i));
+
+  const updateTool = (i: number, patch: Partial<BuildToolSpec>) => {
+    setTools((prev) => prev.map((t, idx) => (idx === i ? { ...t, ...patch } : t)));
+  };
+  const addTool = () => setTools((prev) => [...prev, { ...EMPTY_TOOL }]);
+  const removeTool = (i: number) => setTools((prev) => prev.filter((_, idx) => idx !== i));
+
+  const description = kind === "ui"
+    ? serializeBuildPrompt({ kind: "ui", goal, formFields, artifactTemplate, behavior })
+    : serializeBuildPrompt({ kind: "tool", goal, tools, behavior });
+
   const [error, setError] = useState<string | null>(null);
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     const desc = description.trim();
-    if (!desc) { setError("Description is required."); return; }
+    if (!desc) { setError("Goal is required — describe what this companion is for."); return; }
     const nm = name.trim();
     if (!nm) { setError("Companion name is required."); return; }
     if (!/^[a-z][a-z0-9-]*$/.test(nm)) { setError("Name must be lowercase letters, digits, hyphens; starts with a letter."); return; }
@@ -50,6 +86,19 @@ export default function BuildForm({ onSubmit }: Props) {
     setError(null);
     void onSubmit({ mode: "new-companion", name: nm, kind, description: desc });
   };
+
+  const sectionLabelStyle: React.CSSProperties = { display: "flex", flexDirection: "column", gap: 6 };
+  const inputBaseStyle: React.CSSProperties = {
+    padding: "10px 12px",
+    background: "var(--bg)",
+    color: "var(--ink)",
+    border: "1px solid color-mix(in srgb, var(--ink) 14%, transparent)",
+    borderRadius: 8,
+    fontFamily: "var(--font-body)",
+    fontSize: 14,
+    lineHeight: 1.55,
+  };
+  const textareaStyle: React.CSSProperties = { ...inputBaseStyle, resize: "vertical", minHeight: 100 };
 
   return (
     <div style={{ maxWidth: 920 }}>
@@ -70,8 +119,8 @@ export default function BuildForm({ onSubmit }: Props) {
           )}
           <p className="t-body" style={{ color: "var(--muted)", margin: 0, maxWidth: "62ch" }}>
             {asideExample
-              ? "Prefilled from the example chip. Review the description below and adjust any details before submitting — Build will scaffold the manifest, MCP proxy tools, skill, and pages."
-              : "Describe the tool you want. Name the external service, what data to fetch, and what the output should look like. Build interprets the description and scaffolds everything from there."}
+              ? "Prefilled from the example chip. Review each section below and adjust before submitting — Build will scaffold the manifest, MCP proxy tools, skill, and pages."
+              : "Fill in the four sections below. Build interprets them and scaffolds everything — manifest, MCP proxy tools, skill, and pages."}
           </p>
         </div>
 
@@ -106,7 +155,7 @@ export default function BuildForm({ onSubmit }: Props) {
         )}
 
         <form onSubmit={submit} style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <div style={sectionLabelStyle}>
               <label htmlFor="build-name" className="t-eyebrow">Companion name</label>
               <input
                 id="build-name"
@@ -114,15 +163,7 @@ export default function BuildForm({ onSubmit }: Props) {
                 onChange={(e) => setName(e.target.value)}
                 placeholder="oncall-investigator"
                 pattern="^[a-z][a-z0-9-]*$"
-                style={{
-                  padding: "10px 12px",
-                  background: "var(--bg)",
-                  color: "var(--ink)",
-                  border: "1px solid color-mix(in srgb, var(--ink) 14%, transparent)",
-                  borderRadius: 8,
-                  fontFamily: "var(--font-mono)",
-                  fontSize: 14,
-                }}
+                style={{ ...inputBaseStyle, fontFamily: "var(--font-mono)" }}
               />
               {nameTaken ? (
                 <span className="t-caption" role="alert" style={{ color: "var(--status-error)" }}>
@@ -133,7 +174,7 @@ export default function BuildForm({ onSubmit }: Props) {
               )}
             </div>
 
-            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <div style={sectionLabelStyle}>
               <span className="t-eyebrow" id="kind-label">Kind</span>
               <div role="radiogroup" aria-labelledby="kind-label" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
                 {[
@@ -167,29 +208,196 @@ export default function BuildForm({ onSubmit }: Props) {
               </div>
             </div>
 
-            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <label htmlFor="build-description" className="t-eyebrow">Description</label>
+            <div style={sectionLabelStyle}>
+              <label htmlFor="build-goal" className="t-eyebrow">Goal</label>
               <textarea
-                id="build-description"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                rows={6}
-                placeholder="Describe the companion. Name the external service (GitHub, AWS, Linear, Slack, …), what data to fetch, and what the artifact should contain. Read-only by default — say explicitly if it should write back.&#10;&#10;Example: Review a GitHub PR — fetch the diff and existing comments, flag risky diffs, suggest review questions for the author. Read-only."
-                style={{
-                  padding: "10px 12px",
-                  background: "var(--bg)",
-                  color: "var(--ink)",
-                  border: "1px solid color-mix(in srgb, var(--ink) 14%, transparent)",
-                  borderRadius: 8,
-                  fontFamily: "var(--font-body)",
-                  fontSize: 14,
-                  lineHeight: 1.55,
-                  resize: "vertical",
-                  minHeight: 160,
-                }}
+                id="build-goal"
+                value={goal}
+                onChange={(e) => setGoal(e.target.value)}
+                rows={4}
+                placeholder="What is this companion for / what does it produce? Name the external service (GitHub, AWS, Linear, Slack, …), what data to fetch, and what the artifact represents. Read-only by default — say explicitly if it should write back."
+                style={textareaStyle}
+              />
+              <span className="t-caption">One short paragraph. Build uses this as the headline framing.</span>
+            </div>
+
+            {kind === "ui" && (
+            <div style={sectionLabelStyle}>
+              <span className="t-eyebrow" id="form-fields-label">Form fields</span>
+              <span className="t-caption" style={{ marginBottom: 4 }}>
+                The fields the companion's form will collect. Be specific about format and defaults — Build will turn each into a Zod field with the matching UI hints.
+              </span>
+              <div role="group" aria-labelledby="form-fields-label" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                {formFields.map((f, i) => (
+                  <div key={i} className="card-hairline" style={{ display: "grid", gridTemplateColumns: "200px 110px 1fr auto", gap: 8, alignItems: "start", padding: "10px 12px" }}>
+                    <input
+                      aria-label={`Field ${i + 1} name`}
+                      value={f.name}
+                      onChange={(e) => updateField(i, { name: e.target.value })}
+                      placeholder="field name"
+                      style={{ ...inputBaseStyle, fontFamily: "var(--font-mono)", padding: "8px 10px" }}
+                    />
+                    <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "var(--muted)", padding: "8px 0" }}>
+                      <input
+                        type="checkbox"
+                        checked={f.required}
+                        onChange={(e) => updateField(i, { required: e.target.checked })}
+                      />
+                      required
+                    </label>
+                    <textarea
+                      aria-label={`Field ${i + 1} description`}
+                      value={f.description}
+                      onChange={(e) => updateField(i, { description: e.target.value })}
+                      rows={3}
+                      placeholder="What this field is, expected format, defaults. e.g. 'owner/name format, e.g. sean1588/claudepanion'"
+                      style={{ ...textareaStyle, minHeight: 84, padding: "8px 10px" }}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeField(i)}
+                      disabled={formFields.length === 1}
+                      aria-label={`Remove field ${i + 1}`}
+                      title="Remove field"
+                      style={{
+                        background: "transparent",
+                        border: "1px solid color-mix(in srgb, var(--ink) 14%, transparent)",
+                        borderRadius: 6,
+                        color: "var(--muted)",
+                        cursor: formFields.length === 1 ? "not-allowed" : "pointer",
+                        opacity: formFields.length === 1 ? 0.4 : 1,
+                        padding: "6px 10px",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 13,
+                      }}
+                    >
+                      ✕
+                    </button>
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={addField}
+                  className="t-caption"
+                  style={{
+                    alignSelf: "flex-start",
+                    background: "transparent",
+                    border: "1px dashed color-mix(in srgb, var(--ink) 24%, transparent)",
+                    borderRadius: 6,
+                    color: "var(--accent)",
+                    cursor: "pointer",
+                    padding: "6px 12px",
+                  }}
+                >
+                  + add field
+                </button>
+              </div>
+            </div>
+            )}
+
+            {kind === "ui" && (
+            <div style={sectionLabelStyle}>
+              <label htmlFor="build-artifact" className="t-eyebrow">Artifact template</label>
+              <textarea
+                id="build-artifact"
+                value={artifactTemplate}
+                onChange={(e) => setArtifactTemplate(e.target.value)}
+                rows={8}
+                placeholder={`Sketch the artifact's sections, in markdown. e.g.\n\n1. **Verdict** — 1-2 sentence overall take.\n2. **Risks** — bullets, each citing file:line.\n3. **Address before merge** — grouped Major / Minor / Nits.`}
+                style={{ ...textareaStyle, minHeight: 160, fontFamily: "var(--font-mono)", fontSize: 13 }}
+              />
+              <span className="t-caption">Free-form markdown. The scaffolded skill will follow this shape on every run.</span>
+            </div>
+            )}
+
+            {kind === "tool" && (
+            <div style={sectionLabelStyle}>
+              <span className="t-eyebrow" id="tools-label">Tools</span>
+              <span className="t-caption" style={{ marginBottom: 4 }}>
+                The MCP tools this companion will expose. Build will turn each into a <code>defineTool</code> entry. Args are optional — describe them in plain text (name, type, required/optional, default).
+              </span>
+              <div role="group" aria-labelledby="tools-label" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                {tools.map((t, i) => (
+                  <div key={i} className="card-hairline" style={{ display: "flex", flexDirection: "column", gap: 6, padding: "10px 12px" }}>
+                    <div style={{ display: "grid", gridTemplateColumns: "260px 1fr auto", gap: 8, alignItems: "start" }}>
+                      <input
+                        aria-label={`Tool ${i + 1} name`}
+                        value={t.name}
+                        onChange={(e) => updateTool(i, { name: e.target.value })}
+                        placeholder="tool_name (snake_case)"
+                        style={{ ...inputBaseStyle, fontFamily: "var(--font-mono)", padding: "8px 10px" }}
+                      />
+                      <textarea
+                        aria-label={`Tool ${i + 1} description`}
+                        value={t.description}
+                        onChange={(e) => updateTool(i, { description: e.target.value })}
+                        rows={2}
+                        placeholder="What this tool does + when to use it. Read-only unless stated; if it writes, say so explicitly."
+                        style={{ ...textareaStyle, minHeight: 56, padding: "8px 10px" }}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeTool(i)}
+                        disabled={tools.length === 1}
+                        aria-label={`Remove tool ${i + 1}`}
+                        title="Remove tool"
+                        style={{
+                          background: "transparent",
+                          border: "1px solid color-mix(in srgb, var(--ink) 14%, transparent)",
+                          borderRadius: 6,
+                          color: "var(--muted)",
+                          cursor: tools.length === 1 ? "not-allowed" : "pointer",
+                          opacity: tools.length === 1 ? 0.4 : 1,
+                          padding: "6px 10px",
+                          fontFamily: "var(--font-mono)",
+                          fontSize: 13,
+                        }}
+                      >
+                        ✕
+                      </button>
+                    </div>
+                    <textarea
+                      aria-label={`Tool ${i + 1} args`}
+                      value={t.args}
+                      onChange={(e) => updateTool(i, { args: e.target.value })}
+                      rows={4}
+                      placeholder={`Args (optional). e.g.\nurl: string (required) — URL to fetch\ntimeout_ms: number (optional, default 5000)`}
+                      style={{ ...textareaStyle, minHeight: 96, padding: "8px 10px", fontFamily: "var(--font-mono)", fontSize: 13 }}
+                    />
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={addTool}
+                  className="t-caption"
+                  style={{
+                    alignSelf: "flex-start",
+                    background: "transparent",
+                    border: "1px dashed color-mix(in srgb, var(--ink) 24%, transparent)",
+                    borderRadius: 6,
+                    color: "var(--accent)",
+                    cursor: "pointer",
+                    padding: "6px 12px",
+                  }}
+                >
+                  + add tool
+                </button>
+              </div>
+            </div>
+            )}
+
+            <div style={sectionLabelStyle}>
+              <label htmlFor="build-behavior" className="t-eyebrow">Behavior & constraints</label>
+              <textarea
+                id="build-behavior"
+                value={behavior}
+                onChange={(e) => setBehavior(e.target.value)}
+                rows={4}
+                placeholder="Read-only by default? Auth source (env var, ~/.aws/credentials, etc)? Any defaults Build should bake in?"
+                style={textareaStyle}
               />
               <span className="t-caption">
-                Tip: companions get architectural value from authenticated proxy access to external systems. The form captures <strong>where</strong> to query (which repo / account / team / channel) — not "paste your text here."
+                Anything Build should know about side-effects, auth, defaults, or framework escape hatches (e.g. needing a custom form.tsx for searchable dropdowns).
               </span>
             </div>
 

--- a/skills/build-companion/SKILL.md
+++ b/skills/build-companion/SKILL.md
@@ -133,28 +133,7 @@ It emits one JSON object on stdout. On success: `{ ok: true, stagesRun, filesGen
 
 On any failure call `mcp__claudepanion__build_fail` with `errorMessage: "[<prefix>] <stage>: <error>"`. Do NOT proceed to Step 9.
 
-## Step 9 — Ask the user whether to commit
-
-Show a summary of what was scaffolded (files created, tools, SDK) and ask:
-
-> "Companion `<slug>` scaffolded and self-check passed. Should I commit it to git? (yes / no / skip)"
-
-**Only commit if the user explicitly confirms.** If they say no or skip, proceed directly to Step 10 without running any `git` commands.
-
-If they confirm:
-
-```bash
-cd ~/.claudepanion
-git rev-parse --git-dir 2>/dev/null && \
-  git add companions/<slug> skills/<slug>-companion companions/index.ts companions/client.ts package.json package-lock.json && \
-  git commit -m "companion: scaffold <slug>"
-```
-
-The `cd ~/.claudepanion` + `git rev-parse` check matters: the user's home is only a git repo if they've opted into the dotfile-style workflow (`git init ~/.claudepanion`). If it's not a git repo, skip the commit and tell the user. **Never commit into the framework's own checkout** — companion files don't live there in the user-local install model.
-
-Drop `package.json`/`package-lock.json` from the `git add` if no SDK was added.
-
-## Step 10 — Save artifact + complete
+## Step 9 — Save artifact + complete
 
 The artifact is markdown — what was built, where it lives, what to do next. A good shape:
 
@@ -200,8 +179,7 @@ mcp__claudepanion__build_update_status({ id, status: "completed" })
 5. Bump version in `manifest.ts` — patch for fix/typo, minor for additions, major for breaking.
 6. `claudepanion scaffold <target>`.
 7. Branch on result (Step 8 table above).
-8. Ask the user whether to commit (same gate as Step 9 in new-companion mode). Only run `git add companions/<target> skills/<target>-companion` (+ `package.json` if changed) and commit if they confirm.
-9. `build_save_artifact` (markdown of what changed) + `build_update_status` completed.
+8. `build_save_artifact` (markdown of what changed) + `build_update_status` completed.
 
 ---
 
@@ -496,8 +474,7 @@ Start a new Claude Code session in this repo and paste:
 - About to leave `<<<INSERT PLAYBOOK HERE>>>` (or any placeholder) in the authored SKILL.md.
 - About to mark `completed` without `claudepanion scaffold`'s self-check having passed.
 
-### Hygiene — fix before commit
-- `git add` missed `package.json` (and `package-lock.json`) after a dependency change.
+### Hygiene
 - Skill description is generic ("Helps with X") instead of specific (what data, what action, what credentials).
 - `ArtifactExtras` has fields no list-row override consumes — delete them; rendering is markdown.
 

--- a/tests/client/BuildForm.test.tsx
+++ b/tests/client/BuildForm.test.tsx
@@ -27,25 +27,31 @@ function renderAt(path: string) {
 }
 
 describe("BuildForm ?example= prefill", () => {
-  it("prefills name/kind/description from a known example slug", async () => {
+  it("prefills name/kind/goal/artifact/behavior + field rows from a known example slug", async () => {
     renderAt("/c/build/new?example=github-pr-reviewer");
     const name = await screen.findByLabelText(/companion name/i) as HTMLInputElement;
-    const description = await screen.findByLabelText(/^description$/i) as HTMLTextAreaElement;
-    // Kind is now a radiogroup; find the "ui companion" radio (maps to "ui" kind)
+    const goal = await screen.findByLabelText(/^goal$/i) as HTMLTextAreaElement;
+    const artifact = await screen.findByLabelText(/artifact template/i) as HTMLTextAreaElement;
+    const behavior = await screen.findByLabelText(/behavior & constraints/i) as HTMLTextAreaElement;
     const uiRadio = await screen.findByRole("radio", { name: /ui companion/i });
     await waitFor(() => {
       expect(name.value).toBe("github-pr-reviewer");
       expect(uiRadio).toHaveAttribute("aria-checked", "true");
-      expect(description.value).toMatch(/structured code-review report/i);
+      expect(goal.value).toMatch(/structured code-review report/i);
+      expect(artifact.value).toMatch(/verdict/i);
+      expect(behavior.value).toMatch(/read-only/i);
     });
+    // Structured field rows prefilled — at least the "Repo" row name input is visible.
+    const repoInput = await screen.findByDisplayValue("Repo") as HTMLInputElement;
+    expect(repoInput).toBeInTheDocument();
   });
 
   it("falls back to an empty form when example slug is unknown", async () => {
     renderAt("/c/build/new?example=does-not-exist");
     const name = await screen.findByLabelText(/companion name/i) as HTMLInputElement;
-    const description = await screen.findByLabelText(/^description$/i) as HTMLTextAreaElement;
+    const goal = await screen.findByLabelText(/^goal$/i) as HTMLTextAreaElement;
     expect(name.value).toBe("");
-    expect(description.value).toBe("");
+    expect(goal.value).toBe("");
   });
 
   it("falls back to an empty form when no example param is given", async () => {
@@ -66,9 +72,13 @@ describe("BuildForm ?example= prefill", () => {
     const btn = await screen.findByRole("button", { name: /build companion/i });
     fireEvent.click(btn);
     await waitFor(() => expect(submitted).not.toBeNull());
-    // Chips are form-text-prefill sugar only — example slug must NOT leak into the entity input.
+    // Chips are form-prefill sugar only — example slug must NOT leak into the entity input.
     expect(submitted!).toMatchObject({ mode: "new-companion", name: "github-pr-reviewer" });
     expect((submitted as { example?: string }).example).toBeUndefined();
+    // The serialized description should carry the structured pieces.
+    expect(submitted!.description).toMatch(/structured code-review report/i);
+    expect(submitted!.description).toMatch(/Form fields:/);
+    expect(submitted!.description).toMatch(/\*\*Repo\*\* \(required\)/);
   });
 
   it("blocks submit and shows an error when the companion name is already taken", async () => {
@@ -90,9 +100,9 @@ describe("BuildForm ?example= prefill", () => {
       </MemoryRouter>
     );
     const nameInput = await screen.findByLabelText(/companion name/i) as HTMLInputElement;
-    const descInput = await screen.findByLabelText(/^description$/i) as HTMLTextAreaElement;
+    const goalInput = await screen.findByLabelText(/^goal$/i) as HTMLTextAreaElement;
     fireEvent.change(nameInput, { target: { value: "github-pr-reviewer" } });
-    fireEvent.change(descInput, { target: { value: "another reviewer" } });
+    fireEvent.change(goalInput, { target: { value: "another reviewer" } });
     await waitFor(() => {
       expect(screen.getByText(/already exists/i)).toBeInTheDocument();
     });
@@ -110,12 +120,13 @@ describe("BuildForm ?example= prefill", () => {
       </MemoryRouter>
     );
     const nameInput = await screen.findByLabelText(/companion name/i) as HTMLInputElement;
-    const descInput = await screen.findByLabelText(/^description$/i) as HTMLTextAreaElement;
+    const goalInput = await screen.findByLabelText(/^goal$/i) as HTMLTextAreaElement;
     fireEvent.change(nameInput, { target: { value: "totally-new-thing" } });
-    fireEvent.change(descInput, { target: { value: "fresh companion" } });
+    fireEvent.change(goalInput, { target: { value: "fresh companion" } });
     fireEvent.click(screen.getByRole("button", { name: /build companion/i }));
     await waitFor(() => expect(submitted).not.toBeNull());
     expect(submitted!).toMatchObject({ mode: "new-companion", name: "totally-new-thing" });
+    expect(submitted!.description).toMatch(/fresh companion/);
   });
 
   it("omits example field in submitted input when URL has no ?example=", async () => {
@@ -128,12 +139,71 @@ describe("BuildForm ?example= prefill", () => {
       </MemoryRouter>
     );
     const nameInput = await screen.findByLabelText(/companion name/i) as HTMLInputElement;
-    const descInput = await screen.findByLabelText(/^description$/i) as HTMLTextAreaElement;
+    const goalInput = await screen.findByLabelText(/^goal$/i) as HTMLTextAreaElement;
     fireEvent.change(nameInput, { target: { value: "handwritten" } });
-    fireEvent.change(descInput, { target: { value: "no example" } });
+    fireEvent.change(goalInput, { target: { value: "no example" } });
     fireEvent.click(screen.getByRole("button", { name: /build companion/i }));
     await waitFor(() => expect(submitted).not.toBeNull());
     expect(submitted!).toMatchObject({ mode: "new-companion", name: "handwritten" });
     expect((submitted as { example?: string }).example).toBeUndefined();
+  });
+
+  it("switches to tool kind: hides UI sections, shows Tools, serializes tool list", async () => {
+    let submitted: BuildInput | null = null;
+    render(
+      <MemoryRouter initialEntries={["/c/build/new"]}>
+        <Routes>
+          <Route path="*" element={<BuildForm onSubmit={(i) => { submitted = i; }} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    // Switch kind to tool.
+    const toolRadio = await screen.findByRole("radio", { name: /tool companion/i });
+    fireEvent.click(toolRadio);
+    // UI-only sections gone.
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/^form fields$/i)).toBeNull();
+      expect(screen.queryByLabelText(/artifact template/i)).toBeNull();
+    });
+    // Tools section visible.
+    const firstToolName = await screen.findByLabelText(/tool 1 name/i) as HTMLInputElement;
+    const firstToolDesc = await screen.findByLabelText(/tool 1 description/i) as HTMLTextAreaElement;
+    const firstToolArgs = await screen.findByLabelText(/tool 1 args/i) as HTMLTextAreaElement;
+    // Fill name, goal, tool.
+    fireEvent.change(screen.getByLabelText(/companion name/i), { target: { value: "url-fetcher" } });
+    fireEvent.change(screen.getByLabelText(/^goal$/i), { target: { value: "Fetch URLs and return their content as text." } });
+    fireEvent.change(firstToolName, { target: { value: "fetch_url" } });
+    fireEvent.change(firstToolDesc, { target: { value: "Fetch a URL and return its body as UTF-8 text." } });
+    fireEvent.change(firstToolArgs, { target: { value: "url: string (required) — URL to fetch" } });
+    fireEvent.click(screen.getByRole("button", { name: /build companion/i }));
+    await waitFor(() => expect(submitted).not.toBeNull());
+    expect(submitted!).toMatchObject({ mode: "new-companion", name: "url-fetcher", kind: "tool" });
+    expect(submitted!.description).toMatch(/Tools to expose:/);
+    expect(submitted!.description).toMatch(/\*\*fetch_url\*\*/);
+    expect(submitted!.description).toMatch(/url: string \(required\)/);
+    // No ui-only sections in serialized output.
+    expect(submitted!.description).not.toMatch(/Form fields:/);
+    expect(submitted!.description).not.toMatch(/artifact follows a fixed template/i);
+  });
+
+  it("lets the user add and remove field rows", async () => {
+    renderAt("/c/build/new");
+    // Default: one empty field row.
+    const firstFieldName = await screen.findByLabelText(/field 1 name/i) as HTMLInputElement;
+    expect(firstFieldName).toBeInTheDocument();
+    // Remove button on the only row is disabled.
+    const removeFirst = screen.getByLabelText(/remove field 1/i) as HTMLButtonElement;
+    expect(removeFirst).toBeDisabled();
+    // Add a row.
+    fireEvent.click(screen.getByRole("button", { name: /add field/i }));
+    const secondFieldName = await screen.findByLabelText(/field 2 name/i) as HTMLInputElement;
+    expect(secondFieldName).toBeInTheDocument();
+    // Now remove buttons are enabled.
+    expect((screen.getByLabelText(/remove field 1/i) as HTMLButtonElement).disabled).toBe(false);
+    // Remove row 2.
+    fireEvent.click(screen.getByLabelText(/remove field 2/i));
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/field 2 name/i)).toBeNull();
+    });
   });
 });

--- a/tests/client/NewEntity.test.tsx
+++ b/tests/client/NewEntity.test.tsx
@@ -33,7 +33,7 @@ describe("NewEntity", () => {
     );
     await waitFor(() => expect(screen.getByLabelText(/companion name/i)).toBeInTheDocument());
     fireEvent.change(screen.getByLabelText(/companion name/i), { target: { value: "my-companion" } });
-    fireEvent.change(screen.getByLabelText(/^description$/i), { target: { value: "a test companion" } });
+    fireEvent.change(screen.getByLabelText(/^goal$/i), { target: { value: "a test companion" } });
     fireEvent.click(screen.getByRole("button", { name: /build companion/i }));
     await waitFor(() => expect(screen.getByText("detail-page")).toBeInTheDocument());
   });


### PR DESCRIPTION
## Summary

- Replace the free-form description textarea on Build's **new** tab with a structured form: **Goal**, **Form fields** (rows), **Artifact template**, and **Behavior & constraints** for `ui`-kind companions; **Goal**, **Tools** (rows), and **Behavior** for `tool`-kind. Submit serializes the structured pieces into the same description string Build's skill already understands, so the entity-input contract is unchanged.
- Convert the three example chips (GitHub PR reviewer, CloudWatch investigator, Linear groomer) from prose prompts into the new shape so clicking a chip prefills the structured fields.
- Drop the "commit to git?" step from the build skill — companions land in `~/.claudepanion/` which isn't necessarily a git repo. Users on the dotfile-style workflow can still commit manually.

## Test plan

- [x] `npm run check` clean
- [x] `npm test` — 303 passed (added BuildForm tests for tool-kind serialization + add/remove field rows; updated `NewEntity.test.tsx` to use the `Goal` label)
- [x] `npm run build` clean
- [ ] Smoke: `/c/build/new` renders four labeled sections for `ui`, swaps to Goal + Tools + Behavior on `tool` kind toggle, chip clicks prefill the structured fields
- [ ] Smoke: scaffold a new ui companion end-to-end via the structured form and confirm the resulting entity description carries the same shape Build's skill expects

🤖 Generated with [Claude Code](https://claude.com/claude-code)