### PR TITLE
feat(headless): host-run execution mode for ui companions

### DIFF
--- a/companions/build/examples.ts
+++ b/companions/build/examples.ts
@@ -126,6 +126,13 @@ Notes for Build:
   },
 ];
 
+/**
+ * How a ui companion's entity is driven once submitted.
+ * - "interactive": host shows a `/<slug>-companion <id>` slash command (default).
+ * - "headless": host runs `claude -p` itself, bounded to the companion's tools.
+ */
+export type ExecutionMode = "interactive" | "headless";
+
 export type BuildPromptParts =
   | {
       kind: "ui";
@@ -133,6 +140,7 @@ export type BuildPromptParts =
       formFields: BuildFormField[];
       artifactTemplate: string;
       behavior: string;
+      execution: ExecutionMode;
     }
   | {
       kind: "tool";
@@ -184,6 +192,17 @@ export function serializeBuildPrompt(parts: BuildPromptParts): string {
 
   const behavior = parts.behavior.trim();
   if (behavior) sections.push(`Behavior & constraints:\n${behavior}`);
+
+  if (parts.kind === "ui" && parts.execution === "headless") {
+    sections.push(
+      `Execution mode: HEADLESS. Set \`execution: "headless"\` in the companion's manifest.ts. ` +
+        `This companion runs WITHOUT a slash command — when the form is submitted, the host launches ` +
+        `\`claude -p\` automatically, bounded to this companion's own MCP tools. Because there is no human ` +
+        `in the loop, the skill must never pause for confirmation: any step that would normally ask the ` +
+        `user to confirm should proceed with the safest default and note what it did (and anything skipped) ` +
+        `in the artifact.`
+    );
+  }
 
   return sections.join("\n\n");
 }

--- a/companions/build/form.tsx
+++ b/companions/build/form.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSearchParams, useNavigate, Link } from "react-router-dom";
 import type { BuildInput } from "./types";
-import { buildExamples, serializeBuildPrompt, type BuildFormField, type BuildToolSpec } from "./examples";
+import { buildExamples, serializeBuildPrompt, type BuildFormField, type BuildToolSpec, type ExecutionMode } from "./examples";
 import { useCompanions } from "../../src/client/hooks/useCompanions";
 
 interface Props {
@@ -37,6 +37,7 @@ export default function BuildForm({ onSubmit }: Props) {
     asideExample?.kind === "tool" ? asideExample.tools.map((t) => ({ ...t })) : [{ ...EMPTY_TOOL }]
   );
   const [behavior, setBehavior] = useState(asideExample?.behavior ?? "");
+  const [execution, setExecution] = useState<ExecutionMode>("interactive");
 
   useEffect(() => {
     if (asideExample) {
@@ -47,6 +48,7 @@ export default function BuildForm({ onSubmit }: Props) {
       if (asideExample.kind === "ui") {
         setFormFields(asideExample.formFields.map((f) => ({ ...f })));
         setArtifactTemplate(asideExample.artifactTemplate);
+        setExecution("interactive");
       } else {
         setTools(asideExample.tools.map((t) => ({ ...t })));
       }
@@ -70,7 +72,7 @@ export default function BuildForm({ onSubmit }: Props) {
   const removeTool = (i: number) => setTools((prev) => prev.filter((_, idx) => idx !== i));
 
   const description = kind === "ui"
-    ? serializeBuildPrompt({ kind: "ui", goal, formFields, artifactTemplate, behavior })
+    ? serializeBuildPrompt({ kind: "ui", goal, formFields, artifactTemplate, behavior, execution })
     : serializeBuildPrompt({ kind: "tool", goal, tools, behavior });
 
   const [error, setError] = useState<string | null>(null);
@@ -266,6 +268,48 @@ export default function BuildForm({ onSubmit }: Props) {
                 style={{ minHeight: 160 }}
               />
             </Field>
+          )}
+
+          {/* UI mode: Execution */}
+          {kind === "ui" && (
+            <div>
+              <FieldLabel>execution · how this companion runs once the form is submitted</FieldLabel>
+              <div role="radiogroup" aria-label="Execution mode" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+                {[
+                  { value: "interactive" as const, label: "interactive", hint: "shows a slash command — drive it in your terminal; steer it, ask follow-ups" },
+                  { value: "headless" as const, label: "headless", hint: "runs from the UI — host runs claude itself, bounded to this companion's tools" },
+                ].map((opt) => {
+                  const selected = execution === opt.value;
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      onClick={() => setExecution(opt.value)}
+                      style={{
+                        padding: "10px 12px",
+                        textAlign: "left",
+                        cursor: "pointer",
+                        fontFamily: "var(--font-mono)",
+                        border: "var(--app-border)",
+                        borderColor: selected ? "var(--sage)" : "color-mix(in srgb, var(--ink) 30%, transparent)",
+                        background: selected ? "color-mix(in srgb, var(--sage) 10%, transparent)" : "transparent",
+                        color: "var(--ink)",
+                      }}
+                    >
+                      <div style={{ fontSize: 13, fontWeight: 600 }}>{opt.label}</div>
+                      <div style={{ fontSize: 10, color: "var(--muted)", marginTop: 2 }}>{opt.hint}</div>
+                    </button>
+                  );
+                })}
+              </div>
+              {execution === "headless" && (
+                <Caption>
+                  Headless runs unattended, on your Claude Code auth, using only this companion's tools — no human approves each step.
+                </Caption>
+              )}
+            </div>
           )}
 
           {/* Tool mode: Tools */}

--- a/docs/superpowers/specs/2026-05-30-headless-companions-design.md
+++ b/docs/superpowers/specs/2026-05-30-headless-companions-design.md
@@ -1,0 +1,203 @@
+# Headless companions — design
+
+**Status:** approved (brainstorm), pending implementation plan
+**Date:** 2026-05-30
+
+## Problem
+
+Today, every UI companion's entity is driven the same way: the user submits a
+form in the browser, the host shows a slash command (`/<slug>-companion <id>`),
+and the user pastes it into their **interactive** Claude Code session, which
+drives the entity through the companion's MCP tools.
+
+That interactive flow is genuinely valuable for some tasks — anything where the
+user wants to steer, ask follow-ups, or guide a long-running investigation. But
+for fire-and-forget tasks it imposes real friction: a context switch from the
+browser to a terminal, and dependence on the plugin/slash-command plumbing
+(marketplace registration, `claude plugin install`, "restart your session before
+the new command appears"). For those tasks the user just wants to submit the
+form and watch the result.
+
+## What we're adding
+
+A second way to *launch* a UI companion's entity: **headless**. Instead of the
+human pasting a slash command, the **host** runs `claude -p` itself, pointed at
+the same skill and the same MCP tools. The entity then proceeds exactly as it
+does today — same entity store, same `<slug>_*` MCP tools, same polling UI, same
+artifact. The only thing that changes is **who invokes Claude: the host instead
+of the human.**
+
+This is a launch mechanism, not a second execution engine. Everything downstream
+of the spawn is unchanged.
+
+### Key consequence: headless sidesteps the plugin-plumbing gap
+
+Because the host constructs the whole invocation, a headless companion does
+**not** depend on the slash command, the installed plugin, or the MCP config
+being loadable in the user's cwd. The host inlines the skill's instructions via
+`--append-system-prompt`, passes the entity payload as the prompt, and points
+`--mcp-config` at the companion's own config. None of the plumbing we fought in
+PR #25 is on the critical path for headless companions.
+
+## Goals
+
+- Let a UI companion run end-to-end from the browser with no terminal step.
+- Reuse the entire existing entity lifecycle (store, MCP tools, polling,
+  artifact). No new execution model.
+- Keep the interactive (slash-command) flow as a first-class, equal mode — it is
+  the *correct* mode for steer-and-converse tasks, not a fallback.
+- Make headless **safe by default**: bounded to the companion's sanctioned MCP
+  tools, never arbitrary code execution.
+
+## Non-goals
+
+- **No `--dangerously-skip-permissions` path in v1.** No escape hatch to force
+  headless on a companion that needs raw `Bash`/`Write`. If a real companion
+  later proves it needs that, we add it deliberately, behind its own explicit
+  opt-in.
+- **No hybrid "headless that pauses to ask for input" mode.** Fire-and-forget
+  headless OR full interactive — no middle mode. (The Agent SDK supports mid-run
+  prompts; that's a deliberate future, not v1.)
+- **Tool-kind companions are unaffected** — they have no entity lifecycle, so
+  `execution` is meaningless for them.
+
+## Design
+
+### 1. Manifest field
+
+Add an optional field to `Manifest` (`src/shared/types.ts`):
+
+```ts
+/** How a ui-kind entity is driven. Default: "interactive" (slash command). */
+execution?: "interactive" | "headless";
+```
+
+- Undefined ⇒ `"interactive"`. Existing companions are unchanged; no contract
+  version bump required (additive optional field).
+- Only meaningful for `kind: "ui"`. The validator should warn (not error) if a
+  `tool`-kind manifest sets it.
+
+### 2. Authoring — the Build form + skill
+
+The mode is chosen **at authoring time** by the companion's author, in the
+structured Build form (ui-kind branch only):
+
+- A toggle: **Interactive (slash command)** vs **Headless (runs from the UI)**.
+- `serializeBuildPrompt()` includes the choice; the build skill writes
+  `execution: "headless"` (or omits it for interactive) into the generated
+  `manifest.ts`.
+- Guidance copy next to the toggle, framed on **task shape** first:
+  - *"Want to steer it, ask follow-ups, or guide a long investigation? →
+    Interactive."*
+  - *"Fire-and-forget, watch the result in the browser, never touch the
+    terminal? → Headless."*
+  - Honest caveat: *"Headless runs unattended, on your Claude Code auth, using
+    only this companion's tools — no human approves each step."*
+
+### 3. The headless runner (one new bounded unit)
+
+New module: `src/server/headless-runner.ts`. Single responsibility: given a
+pending entity for a headless companion, run Claude and stream its output into
+the entity log.
+
+Hook point: `POST /api/entities` (`api-routes.ts:161`). After `store.create`,
+if `registry.get(companion).manifest.execution === "headless"`, hand the entity
+to the runner (fire-and-forget; the route still returns 201 immediately, UI
+polls as today).
+
+The runner spawns:
+
+```
+claude -p "<entity payload prompt>" \
+  --append-system-prompt "<inlined SKILL.md instructions>" \
+  --mcp-config <~/.claudepanion/.mcp.json or per-run config> \
+  --strict-mcp-config \
+  --allowedTools "mcp__claudepanion__<slug>_*" \
+  --output-format stream-json --include-partial-messages
+```
+
+- `--strict-mcp-config` ⇒ the run sees **only** the companion's MCP server.
+- `--allowedTools` ⇒ bounded to the companion's own tools (+ read-only as
+  needed). Default permission mode; non-allowed tools are denied (loud, safe) —
+  no `--dangerously-skip-permissions`.
+- Parse the stream-json and append to the entity log via the existing
+  `_append_log` path. The entity transitions pending→running→completed/error
+  driven by the MCP tools the headless Claude calls — identical to interactive.
+
+Process lifecycle (the runner owns this):
+- Track the child process by entity id.
+- Entity cancel ⇒ kill the process.
+- Timeout ⇒ kill + mark entity error.
+- Process crash / non-zero exit without a terminal MCP call ⇒ mark entity error
+  (via `_fail` / store).
+- Concurrency cap (small semaphore) so a burst of submissions can't fork-bomb
+  the host. Default cap chosen at implementation time.
+
+### 4. Submit-time UI
+
+A single boundary branch on `manifest.execution`:
+
+- **Headless** ⇒ submit transitions straight to the running view; watch live. No
+  slash command shown.
+- **Interactive** ⇒ submit shows the slash command (today's behavior).
+
+This is a feature flag at the boundary, not scattered dispatch.
+
+### 5. The Build companion stays interactive
+
+Build is itself a ui-kind companion. Its `execution` is **interactive** (omits
+the field). This is correct, not an exception: Build writes files and runs
+`claudepanion scaffold` (bash), and its loop is conversational (describe →
+scaffold → look → refine → "now change X"). That's the textbook "reaches into
+the environment + you want to steer it" shape, which our allowlist rule keeps
+out of headless — running Build headless would mean granting `Write`/`Bash` to
+an agent spawned by a form POST, the exact footgun this design refuses.
+
+Build's *new* responsibility is at the authoring layer: it is the tool that
+writes the `execution` field into **other** companions' manifests (via the form
+toggle in §2). It is interactive itself; it confers headless-ness on others. It
+is not a special dual-mode companion.
+
+> Future note: if Build ever authored files through sanctioned MCP tools
+> (issue #23, MCP-mediated writes) instead of raw `Write`/`Bash`, it would be
+> confined to the allowlist and *could* go headless. Out of scope here, and
+> interactive is likely the right default for Build regardless.
+
+## Security considerations
+
+- **Bounded blast radius by construction.** Headless never gets `Bash`/`Write`
+  to arbitrary paths; it is restricted to the companion's `mcp__claudepanion__*`
+  tools via `--allowedTools` + `--strict-mcp-config`. The residual risk is
+  "runs unattended and spends tokens," plus whatever those tools can already do
+  by design.
+- **Auto-execution on POST.** Headless changes `POST /api/entities` from "create
+  a pending record" to "create a record *and* spawn an agent." Confirm the host
+  binds localhost only, and consider an origin/`Host`-header check on the entity
+  route so a malicious web page can't trigger headless runs cross-origin. The
+  bounded allowlist limits damage even if one slips through, but defense in
+  depth is cheap here.
+- **Auth/billing.** Headless uses the machine's logged-in `claude` auth. Token
+  spend happens server-side and is invisible to any interactive session — noted
+  in the UI guidance copy.
+
+## Testing
+
+- Manifest: `execution` defaults to interactive when absent; validator warns on
+  `tool`-kind misuse.
+- Runner: builds the expected `claude -p` argv (allowlist, strict-mcp-config,
+  no skip-permissions); maps stream-json → log entries; cancel kills the
+  process; crash marks the entity error; concurrency cap holds.
+- Route: headless companion ⇒ runner invoked after create; interactive
+  companion ⇒ runner NOT invoked.
+- UI: headless submit shows the running view (no slash command); interactive
+  submit shows the slash command.
+- Build form: toggle round-trips through `serializeBuildPrompt()`; build skill
+  emits `execution: "headless"`.
+
+## Deferred / open
+
+- `--dangerously-skip-permissions` escape hatch (explicitly out of v1).
+- Scoped-`Bash`/`Write` headless companions (would need the allowlist-scoping
+  safety questions answered first).
+- Headless Build via issue #23 (MCP-mediated writes).
+- Concurrency cap default value — decided at implementation.

--- a/skills/build-companion/SKILL.md
+++ b/skills/build-companion/SKILL.md
@@ -68,6 +68,7 @@ Read `entity.input.description` and decide all of:
 4. **Artifact extras** — typed fields beyond `summary`/`markdown`, only if a list-row override needs them. Otherwise `Artifact = BaseArtifact;`.
 5. **Proxy tools** — one per API call, named `<slug_with_underscores>_<verb>`.
 6. **SDK + credential helper** — see the table below.
+7. **Execution mode** — if the description includes `Execution mode: HEADLESS`, this companion runs without a slash command (the host launches `claude -p` on submit). Set `execution: "headless"` in the manifest, and write the skill so it never pauses for user confirmation — any normally-confirmed step proceeds with the safest default and is noted in the artifact. Otherwise it's interactive (the default) and the skill may converse as usual.
 
 ## Step 3 — Echo the interpretation, pause
 
@@ -96,7 +97,7 @@ Author real domain content for each file based on Step 2's interpretation. No to
 
 | File | Contents |
 |---|---|
-| `companions/<slug>/manifest.ts` | `name`, `kind: "ui"`, `displayName`, `icon`, `description`, `contractVersion: "2"`, `version: "0.1.0"`, `requiredEnv`. |
+| `companions/<slug>/manifest.ts` | `name`, `kind: "ui"`, `displayName`, `icon`, `description`, `contractVersion: "2"`, `version: "0.1.0"`, `requiredEnv`. **If the description says `Execution mode: HEADLESS`, also add `execution: "headless"`** — otherwise omit it (the field defaults to interactive). |
 | `companions/<slug>/types.ts` | `InputSchema = z.object({...})` with `.describe()` and `.meta({ ui: ... })`. Optional `ArtifactExtras`. Default `Artifact = BaseArtifact;`. |
 | `companions/<slug>/server/tools.ts` | One `defineTool({...})` per proxy tool. Inline error classifier mapping the SDK's errors onto `[config]` / `[input]` / `[transient]`. `sideEffect: "write"` on write tools with explicit consequence in the description. |
 | `skills/<slug>-companion/SKILL.md` | Frontmatter + CRITICAL block + **Step 0 (verify MCP)** + Steps 1–6. Step 4 is a sequenced playbook of `mcp__claudepanion__<slug>_*` tool calls + log lines — one sub-step per tool. Write tools get the user-permission stanza. |

--- a/src/client/pages/EntityDetail.tsx
+++ b/src/client/pages/EntityDetail.tsx
@@ -22,23 +22,31 @@ export default function EntityDetail() {
 
   const isBuild = entity.companion === "build";
   const steps = isBuild ? deriveSteps(entity) : null;
+  // Headless companions are driven by the host — no slash command to hand off.
+  const headless = manifest?.execution === "headless";
 
   return (
     <div style={{ padding: "22px 28px 60px", maxWidth: 1100 }}>
-      <Title entity={entity} />
+      <Title entity={entity} headless={headless} />
 
       {entity.status === "pending" && (
         <>
-          <PendingBanner entity={entity} />
-          <SlashHero entity={entity} />
-          <LogsCard entity={entity} pending />
+          {headless ? (
+            <HeadlessHero />
+          ) : (
+            <>
+              <PendingBanner entity={entity} />
+              <SlashHero entity={entity} />
+            </>
+          )}
+          <LogsCard entity={entity} pending headless={headless} />
         </>
       )}
 
       {entity.status === "running" && (
         <>
           <RunningStatus entity={entity} steps={steps} />
-          <SlashCollapsed entity={entity} />
+          {!headless && <SlashCollapsed entity={entity} />}
           <LogsCard entity={entity} />
           {steps && <StepsCard steps={steps} />}
         </>
@@ -62,9 +70,9 @@ export default function EntityDetail() {
   );
 }
 
-function Title({ entity }: { entity: Entity }) {
+function Title({ entity, headless = false }: { entity: Entity; headless?: boolean }) {
   const subline = (() => {
-    if (entity.status === "pending") return `waiting for handoff`;
+    if (entity.status === "pending") return headless ? `starting headless run` : `waiting for handoff`;
     if (entity.status === "running") return `claude is working`;
     if (entity.status === "completed") return `scaffold complete`;
     return `build failed`;
@@ -174,6 +182,35 @@ function SlashHero({ entity }: { entity: Entity }) {
   );
 }
 
+function HeadlessHero() {
+  return (
+    <div className="wb-card" style={{ marginBottom: 12, borderColor: "var(--accent)" }}>
+      <div
+        className="wb-card-header wb-section-label"
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          color: "var(--accent)",
+          background: "color-mix(in srgb, var(--accent) 10%, transparent)",
+          borderBottomColor: "color-mix(in srgb, var(--accent) 30%, transparent)",
+        }}
+      >
+        <span>running headlessly</span>
+        <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span className="wb-pulse" style={{ background: "var(--accent)" }} />polling every 2s
+        </span>
+      </div>
+      <div style={{ padding: 14 }}>
+        <div className="wb-sans" style={{ fontSize: 13, color: "var(--muted)", lineHeight: 1.6 }}>
+          claudepanion is running this companion for you — no terminal step. Claude works through this
+          companion's tools and the result appears here when it's done.
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function SlashCollapsed({ entity }: { entity: Entity }) {
   const cmd = `/${entity.companion}-companion ${entity.id}`;
   return (
@@ -224,7 +261,7 @@ function RunningStatus({ entity, steps }: { entity: Entity; steps: DerivedStep[]
   );
 }
 
-function LogsCard({ entity, pending = false }: { entity: Entity; pending?: boolean }) {
+function LogsCard({ entity, pending = false, headless = false }: { entity: Entity; pending?: boolean; headless?: boolean }) {
   const lines = (entity.logs ?? []).map((l) => l.message);
   const polling = entity.status === "running" || entity.status === "pending";
   if (pending && lines.length === 0) {
@@ -250,7 +287,7 @@ function LogsCard({ entity, pending = false }: { entity: Entity; pending?: boole
           }}
         >
           <div>// waiting for claude to start…</div>
-          <div>// logs stream here once the slash command is run</div>
+          <div>{headless ? "// claude is starting — logs stream here as it works" : "// logs stream here once the slash command is run"}</div>
         </div>
       </div>
     );

--- a/src/server/api-routes.ts
+++ b/src/server/api-routes.ts
@@ -3,7 +3,7 @@ import type { EntityStore } from "./entity-store.js";
 import type { Registry } from "./companion-registry.js";
 import type { ReliabilitySnapshot, MountFailure } from "./reliability/watcher.js";
 import { generateEntityId } from "./id.js";
-import type { CompanionToolDefinition } from "../shared/types.js";
+import type { CompanionToolDefinition, Entity } from "../shared/types.js";
 import { spawn } from "node:child_process";
 import { validateCompanion } from "./reliability/validator.js";
 import type { RegisteredCompanion } from "./companion-registry.js";
@@ -53,9 +53,11 @@ export interface ApiDeps {
   deleteCompanionFiles?: (slug: string) => Promise<{ ok: true } | { ok: false; error: string }>;
   /** Triggers a fresh re-import of the companion module. Wired to the watcher in production. */
   triggerRemount?: (slug: string) => Promise<{ ok: true; version?: string } | { ok: false; error: string }>;
+  /** Launches a headless run for a just-created entity. Wired to the headless runner in production; absent in tests. */
+  runHeadless?: (entity: Entity) => void;
 }
 
-export function mountApiRoutes(app: Express, { store, registry, reliability, mountFailures, deleteCompanionFiles, triggerRemount }: ApiDeps): void {
+export function mountApiRoutes(app: Express, { store, registry, reliability, mountFailures, deleteCompanionFiles, triggerRemount, runHeadless }: ApiDeps): void {
   const runDelete = deleteCompanionFiles ?? defaultDeleteCompanionFiles;
 
   // Works even when the companion is NOT registered — that's the whole point:
@@ -154,11 +156,17 @@ export function mountApiRoutes(app: Express, { store, registry, reliability, mou
     if (!companion || typeof companion !== "string") {
       return res.status(400).json({ error: "companion required" });
     }
-    if (!registry.get(companion)) {
+    const c = registry.get(companion);
+    if (!c) {
       return res.status(404).json({ error: `unknown companion: ${companion}` });
     }
     const id = generateEntityId(companion);
     const entity = await store.create({ id, companion, input: input ?? {} });
+    // Headless ui companions are driven by the host, not a slash command: kick
+    // off the run now. Fire-and-forget — the client polls the entity as usual.
+    if (c.manifest.kind === "ui" && c.manifest.execution === "headless") {
+      runHeadless?.(entity);
+    }
     res.status(201).json(entity);
   });
 

--- a/src/server/boot.ts
+++ b/src/server/boot.ts
@@ -13,6 +13,7 @@ import { mountApiRoutes } from "./api-routes.js";
 import { buildMcpServer } from "./mcp.js";
 import { createMcpHttp } from "./mcp-http.js";
 import { createWatcher, type ReliabilitySnapshot, type MountFailure } from "./reliability/watcher.js";
+import { createHeadlessRunner } from "./headless-runner.js";
 import { dataPath, ensureClaudepanionDirs } from "./paths.js";
 import { writeMcpConfig, DEFAULT_MCP_PORT } from "./mcp-config.js";
 
@@ -82,6 +83,7 @@ export async function bootServer(opts: BootOptions): Promise<void> {
     snapshots,
     mountFailures,
   });
+  const headlessRunner = createHeadlessRunner({ store, registry, homeRoot: repoRoot });
 
   const app = express();
   app.use(express.json({ limit: "10mb" }));
@@ -91,6 +93,7 @@ export async function bootServer(opts: BootOptions): Promise<void> {
     registry,
     reliability: snapshots,
     mountFailures,
+    runHeadless: (entity) => headlessRunner.run(entity),
     triggerRemount: async (slug) => {
       try {
         await watcher.triggerRemount(slug);
@@ -121,6 +124,7 @@ export async function bootServer(opts: BootOptions): Promise<void> {
   });
 
   const shutdown = async () => {
+    headlessRunner.cancelAll();
     await mcpHttp.closeAll();
     await watcher.close();
     process.exit(0);

--- a/src/server/headless-runner.ts
+++ b/src/server/headless-runner.ts
@@ -1,0 +1,245 @@
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Entity } from "../shared/types.js";
+import type { EntityStore } from "./entity-store.js";
+import type { Registry, RegisteredCompanion } from "./companion-registry.js";
+import { entityToolNames } from "./mcp.js";
+
+/** The MCP server name companions register under (see `.mcp.json` / mcp-config.ts). */
+const MCP_SERVER_NAME = "claudepanion";
+
+const DEFAULT_MAX_CONCURRENT = 2;
+const DEFAULT_TIMEOUT_MS = 10 * 60_000;
+/** Cap on captured stdout/stderr kept for crash diagnostics. */
+const OUTPUT_CAP = 20_000;
+
+export type SpawnFn = (
+  command: string,
+  args: string[],
+  options: { cwd: string; stdio: ["ignore", "pipe", "pipe"] }
+) => ChildProcess;
+
+export interface HeadlessRunnerDeps {
+  store: EntityStore;
+  registry: Registry;
+  /** Runtime root (`~/.claudepanion`) — holds `.mcp.json` and `skills/`. */
+  homeRoot: string;
+  /** Override the spawner (tests). */
+  spawnFn?: SpawnFn;
+  /** Override the claude binary (default: "claude"). */
+  claudeBin?: string;
+  /** Read a companion's SKILL.md (tests inject; default reads from disk). */
+  readSkill?: (slug: string) => Promise<string>;
+  maxConcurrent?: number;
+  timeoutMs?: number;
+}
+
+export interface HeadlessRunner {
+  /** Queue an entity for a headless run. Fire-and-forget; respects the concurrency cap. */
+  run(entity: Entity): void;
+  /** Kill a running (or drop a queued) headless run. Returns false if not found. */
+  cancel(companion: string, id: string): boolean;
+  /** Kill every in-flight run — used on shutdown. */
+  cancelAll(): void;
+  activeCount(): number;
+}
+
+// ─── Pure builders (unit-tested directly) ────────────────────────────────────
+
+/**
+ * The `--allowedTools` allowlist for a headless run: ONLY this companion's MCP
+ * tools (lifecycle + its own proxy tools), qualified as `mcp__<server>__<tool>`.
+ * Bounds the run to the companion's sanctioned surface — no Bash, no Write, no
+ * other companion's tools. Never includes a skip-permissions escape.
+ */
+export function companionAllowedTools(c: RegisteredCompanion): string[] {
+  const lifecycle = c.manifest.kind === "ui" ? entityToolNames(c.manifest.name) : [];
+  const proxy = c.tools.map((t) => t.name);
+  return [...lifecycle, ...proxy].map((name) => `mcp__${MCP_SERVER_NAME}__${name}`);
+}
+
+/** The user prompt handed to `claude -p` — mirrors what the slash command triggers. */
+export function buildHeadlessPrompt(slug: string, entityId: string): string {
+  return [
+    `You are running headlessly (there is NO human in this session) to process a claudepanion entity.`,
+    `Follow the appended skill instructions exactly.`,
+    ``,
+    `Companion: ${slug}`,
+    `Entity ID: ${entityId}`,
+    ``,
+    `Start by loading the entity with the \`${slug}_get\` MCP tool, do the work, and drive every status/log/artifact update through the claudepanion MCP tools.`,
+    `Because no human can confirm anything: never pause to wait for confirmation. If a skill step would normally ask the user to confirm an action, proceed with the safest available default and record what you did — and anything you skipped — in the artifact's notes.`,
+    `When you finish you MUST have called the save_artifact tool and set status to "completed", or called the fail tool on an unrecoverable error.`,
+  ].join("\n");
+}
+
+/**
+ * The argv for the headless `claude` invocation. Deliberately omits
+ * `--dangerously-skip-permissions`: tools outside the allowlist are denied
+ * (loud, safe) rather than auto-run.
+ */
+export function buildClaudeArgs(opts: {
+  prompt: string;
+  skillInstructions: string;
+  mcpConfigPath: string;
+  allowedTools: string[];
+}): string[] {
+  return [
+    "-p",
+    opts.prompt,
+    "--append-system-prompt",
+    opts.skillInstructions,
+    "--mcp-config",
+    opts.mcpConfigPath,
+    "--strict-mcp-config",
+    "--allowedTools",
+    opts.allowedTools.join(","),
+  ];
+}
+
+// ─── Runner ───────────────────────────────────────────────────────────────────
+
+export function createHeadlessRunner(deps: HeadlessRunnerDeps): HeadlessRunner {
+  const spawnFn = deps.spawnFn ?? (nodeSpawn as unknown as SpawnFn);
+  const claudeBin = deps.claudeBin ?? "claude";
+  const maxConcurrent = deps.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const readSkill =
+    deps.readSkill ??
+    ((slug: string) => readFile(join(deps.homeRoot, "skills", `${slug}-companion`, "SKILL.md"), "utf8"));
+
+  const queue: Entity[] = [];
+  // value === null means the slot is reserved while we await the async skill read.
+  const active = new Map<string, ChildProcess | null>();
+  const cancelledWhileStarting = new Set<string>();
+
+  const key = (companion: string, id: string) => `${companion}/${id}`;
+
+  function pump(): void {
+    while (active.size < maxConcurrent && queue.length > 0) {
+      const entity = queue.shift()!;
+      active.set(key(entity.companion, entity.id), null); // reserve synchronously
+      void start(entity);
+    }
+  }
+
+  async function finish(k: string): Promise<void> {
+    active.delete(k);
+    cancelledWhileStarting.delete(k);
+    pump();
+  }
+
+  async function start(entity: Entity): Promise<void> {
+    const k = key(entity.companion, entity.id);
+    const c = deps.registry.get(entity.companion);
+    if (!c) {
+      await deps.store.fail(entity.companion, entity.id, `[headless] companion not registered: ${entity.companion}`);
+      return finish(k);
+    }
+
+    let skill: string;
+    try {
+      skill = await readSkill(entity.companion);
+    } catch (err) {
+      await deps.store.fail(
+        entity.companion,
+        entity.id,
+        `[headless] could not read skill for ${entity.companion}: ${(err as Error).message}`
+      );
+      return finish(k);
+    }
+
+    const args = buildClaudeArgs({
+      prompt: buildHeadlessPrompt(entity.companion, entity.id),
+      skillInstructions: skill,
+      mcpConfigPath: join(deps.homeRoot, ".mcp.json"),
+      allowedTools: companionAllowedTools(c),
+    });
+
+    let child: ChildProcess;
+    try {
+      child = spawnFn(claudeBin, args, { cwd: deps.homeRoot, stdio: ["ignore", "pipe", "pipe"] });
+    } catch (err) {
+      await deps.store.fail(entity.companion, entity.id, `[headless] failed to spawn claude: ${(err as Error).message}`);
+      return finish(k);
+    }
+
+    // Cancelled during the async skill read, before the process existed.
+    if (cancelledWhileStarting.has(k)) {
+      child.kill("SIGTERM");
+    }
+    active.set(k, child);
+
+    let output = "";
+    const capture = (d: Buffer) => {
+      output += d.toString();
+      if (output.length > OUTPUT_CAP) output = output.slice(-OUTPUT_CAP);
+    };
+    child.stdout?.on("data", capture);
+    child.stderr?.on("data", capture);
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+
+    child.on("error", async (err: Error) => {
+      clearTimeout(timer);
+      await deps.store.fail(entity.companion, entity.id, `[headless] claude process error: ${err.message}`);
+      await finish(k);
+    });
+
+    child.on("close", async (code: number | null, signal: string | null) => {
+      clearTimeout(timer);
+      // The skill drives status through MCP. Only mark a failure if the process
+      // ended without the entity reaching a terminal state.
+      try {
+        const fresh = await deps.store.get(entity.companion, entity.id);
+        const terminal = fresh != null && (fresh.status === "completed" || fresh.status === "error");
+        if (!terminal) {
+          const reason = timedOut
+            ? `timed out after ${Math.round(timeoutMs / 1000)}s`
+            : `exited (code ${code ?? "null"}${signal ? `, signal ${signal}` : ""}) without completing`;
+          await deps.store.fail(
+            entity.companion,
+            entity.id,
+            `[headless] claude ${reason}.${output ? ` Output tail:\n${output.slice(-2000)}` : ""}`
+          );
+        }
+      } finally {
+        await finish(k);
+      }
+    });
+  }
+
+  return {
+    run(entity) {
+      queue.push(entity);
+      pump();
+    },
+    cancel(companion, id) {
+      const k = key(companion, id);
+      if (active.has(k)) {
+        const child = active.get(k);
+        if (child) child.kill("SIGTERM");
+        else cancelledWhileStarting.add(k); // reserved but not yet spawned
+        return true;
+      }
+      const idx = queue.findIndex((e) => e.companion === companion && e.id === id);
+      if (idx >= 0) {
+        queue.splice(idx, 1);
+        return true;
+      }
+      return false;
+    },
+    cancelAll() {
+      queue.length = 0;
+      for (const child of active.values()) child?.kill("SIGTERM");
+    },
+    activeCount() {
+      return active.size;
+    },
+  };
+}

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -24,6 +24,26 @@ export interface McpHandle {
 const STATUS_SCHEMA = z.enum(["pending", "running", "completed", "error"]);
 const LOG_LEVEL_SCHEMA = z.enum(["info", "warn", "error"]);
 
+/**
+ * Suffixes of the lifecycle MCP tools every ui-kind companion gets. The single
+ * source of truth for these names — `buildEntityTools` below and the headless
+ * runner's allowlist both derive from it, so they can't drift. A guard test in
+ * tests/server/mcp.test.ts asserts the registered names match `entityToolNames`.
+ */
+export const ENTITY_TOOL_SUFFIXES = [
+  "get",
+  "list",
+  "update_status",
+  "append_log",
+  "save_artifact",
+  "fail",
+] as const;
+
+/** The fully-qualified lifecycle tool names for a ui companion (e.g. `build_get`). */
+export function entityToolNames(companionName: string): string[] {
+  return ENTITY_TOOL_SUFFIXES.map((s) => `${companionName}_${s}`);
+}
+
 function buildEntityTools(store: EntityStore, c: RegisteredCompanion): CompanionToolDefinition[] {
   const n = c.manifest.name;
   const label = c.manifest.displayName;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -45,6 +45,15 @@ export interface Manifest {
   description: string;
   contractVersion: string;
   version: string;
+  /**
+   * How a ui-kind entity is driven once its form is submitted.
+   * - "interactive" (default): the host shows a `/<slug>-companion <id>` slash
+   *   command; the user drives the entity from their Claude Code session.
+   * - "headless": the host runs `claude -p` itself, bounded to this companion's
+   *   MCP tools, and the entity completes without a terminal step.
+   * Undefined ⇒ "interactive". Meaningless for kind: "tool".
+   */
+  execution?: "interactive" | "headless";
   /** Env vars the companion requires. Preflight surfaces missing values; form blocks submission. */
   requiredEnv?: string[];
   /** Env vars that enable extra features but aren't required. Preflight surfaces as soft warning. */

--- a/tests/client/BuildForm.test.tsx
+++ b/tests/client/BuildForm.test.tsx
@@ -186,6 +186,42 @@ describe("BuildForm ?example= prefill", () => {
     expect(submitted!.description).not.toMatch(/artifact follows a fixed template/i);
   });
 
+  it("defaults to interactive execution (no headless instruction in the description)", async () => {
+    let submitted: BuildInput | null = null;
+    render(
+      <MemoryRouter initialEntries={["/c/build/new"]}>
+        <Routes>
+          <Route path="*" element={<BuildForm onSubmit={(i) => { submitted = i; }} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    fireEvent.change(await screen.findByLabelText(/companion name/i), { target: { value: "plain-thing" } });
+    fireEvent.change(screen.getByLabelText(/^goal$/i), { target: { value: "do a plain thing" } });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await waitFor(() => expect(submitted).not.toBeNull());
+    expect(submitted!.description).not.toMatch(/HEADLESS/);
+    expect(submitted!.description).not.toMatch(/execution:/);
+  });
+
+  it("emits a headless manifest instruction when headless execution is selected", async () => {
+    let submitted: BuildInput | null = null;
+    render(
+      <MemoryRouter initialEntries={["/c/build/new"]}>
+        <Routes>
+          <Route path="*" element={<BuildForm onSubmit={(i) => { submitted = i; }} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    fireEvent.change(await screen.findByLabelText(/companion name/i), { target: { value: "auto-thing" } });
+    fireEvent.change(screen.getByLabelText(/^goal$/i), { target: { value: "do it unattended" } });
+    fireEvent.click(screen.getByRole("radio", { name: /headless/i }));
+    // The honest caveat is surfaced once headless is chosen.
+    expect(screen.getByText(/no human approves each step/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await waitFor(() => expect(submitted).not.toBeNull());
+    expect(submitted!.description).toMatch(/execution: "headless"/);
+  });
+
   it("lets the user add and remove field rows", async () => {
     renderAt("/c/build/new");
     // Default: one empty field row.

--- a/tests/client/EntityDetail.test.tsx
+++ b/tests/client/EntityDetail.test.tsx
@@ -77,6 +77,7 @@ vi.mock("../../src/client/api", () => ({
   fetchCompanions: vi.fn().mockResolvedValue([
     { name: "x", kind: "ui", displayName: "X", icon: "x", description: "x", contractVersion: "2", version: "0.1.0" },
     { name: "build", kind: "ui", displayName: "Build", icon: "🔨", description: "", contractVersion: "2", version: "0.1.0" },
+    { name: "hx", kind: "ui", displayName: "HX", icon: "h", description: "headless one", contractVersion: "2", version: "0.1.0", execution: "headless" },
   ]),
   continueEntity: vi.fn().mockResolvedValue({}),
 }));
@@ -107,6 +108,15 @@ describe("EntityDetail", () => {
     renderAt("/c/x/x-1");
     expect(screen.getByText("/x-companion x-1")).toBeInTheDocument();
     expect(screen.getByText(/pending/i)).toBeInTheDocument();
+  });
+
+  it("shows the headless hero (no slash command) for a pending headless companion", async () => {
+    mockEntityFn.mockReturnValue(baseEntity({ companion: "hx", id: "hx-1", status: "pending" }));
+    mockMcpFn.mockReturnValue({ loading: false, firstRequestAt: null, lastRequestAt: null });
+    renderAt("/c/hx/hx-1");
+    expect(await screen.findByText(/running headlessly/i)).toBeInTheDocument();
+    expect(screen.queryByText("/hx-companion hx-1")).not.toBeInTheDocument();
+    expect(screen.queryByText(/hand off to claude/i)).not.toBeInTheDocument();
   });
 
   it("renders logs in running state", () => {

--- a/tests/client/build-examples.test.ts
+++ b/tests/client/build-examples.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildExamples, type BuildExample } from "../../companions/build/examples";
+import { buildExamples, serializeBuildPrompt, type BuildExample } from "../../companions/build/examples";
 
 const SLUG_RE = /^[a-z][a-z0-9-]*$/;
 
@@ -22,5 +22,28 @@ describe("buildExamples", () => {
   it("has unique slugs", () => {
     const slugs = buildExamples.map((e) => e.slug);
     expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+describe("serializeBuildPrompt execution mode", () => {
+  const uiParts = {
+    kind: "ui" as const,
+    goal: "Do a thing",
+    formFields: [],
+    artifactTemplate: "",
+    behavior: "Read-only.",
+  };
+
+  it("emits a HEADLESS instruction when execution is headless", () => {
+    const out = serializeBuildPrompt({ ...uiParts, execution: "headless" });
+    expect(out).toContain('execution: "headless"');
+    expect(out).toMatch(/WITHOUT a slash command/);
+    expect(out).toMatch(/never pause for confirmation/);
+  });
+
+  it("says nothing about execution for interactive (manifest omits the field)", () => {
+    const out = serializeBuildPrompt({ ...uiParts, execution: "interactive" });
+    expect(out).not.toMatch(/execution:/);
+    expect(out).not.toMatch(/HEADLESS/);
   });
 });

--- a/tests/server/api-routes.test.ts
+++ b/tests/server/api-routes.test.ts
@@ -128,6 +128,31 @@ describe("api routes", () => {
     expect(res.status).toBe(404);
   });
 
+  it("POST /api/entities does NOT launch a headless run for an interactive companion", async () => {
+    const launched: string[] = [];
+    const store = createEntityStore(tmp);
+    const registry = createRegistry([{ manifest: manifest("x"), tools: [] }]);
+    const app2 = express();
+    app2.use(express.json());
+    mountApiRoutes(app2, { store, registry, runHeadless: (e) => launched.push(e.id) });
+    await request(app2).post("/api/entities").send({ companion: "x", input: {} });
+    expect(launched).toEqual([]);
+  });
+
+  it("POST /api/entities launches a headless run for a headless companion", async () => {
+    const launched: string[] = [];
+    const store = createEntityStore(tmp);
+    const registry = createRegistry([
+      { manifest: { ...manifest("hx"), execution: "headless" }, tools: [] },
+    ]);
+    const app2 = express();
+    app2.use(express.json());
+    mountApiRoutes(app2, { store, registry, runHeadless: (e) => launched.push(e.id) });
+    const res = await request(app2).post("/api/entities").send({ companion: "hx", input: {} });
+    expect(res.status).toBe(201);
+    expect(launched).toEqual([res.body.id]);
+  });
+
   it("GET /api/entities/:id round-trips a created entity", async () => {
     const create = await request(app)
       .post("/api/entities")

--- a/tests/server/headless-runner.test.ts
+++ b/tests/server/headless-runner.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createEntityStore } from "../../src/server/entity-store";
+import { createRegistry } from "../../src/server/companion-registry";
+import {
+  createHeadlessRunner,
+  companionAllowedTools,
+  buildHeadlessPrompt,
+  buildClaudeArgs,
+  type SpawnFn,
+} from "../../src/server/headless-runner";
+import type { Manifest, CompanionToolDefinition } from "../../src/shared/types.js";
+import { successResult } from "../../src/shared/types.js";
+
+const manifest = (name: string, kind: "ui" | "tool" = "ui"): Manifest => ({
+  name,
+  kind,
+  displayName: name,
+  icon: "🧪",
+  description: "t",
+  contractVersion: "2",
+  version: "0.0.1",
+});
+
+const tool = (name: string): CompanionToolDefinition => ({
+  name,
+  description: "",
+  schema: {},
+  async handler() {
+    return successResult({});
+  },
+});
+
+const companion = (name: string, tools: string[] = [], kind: "ui" | "tool" = "ui") => ({
+  manifest: manifest(name, kind),
+  tools: tools.map(tool),
+});
+
+/** Minimal stand-in for a spawned `claude` process. */
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  killed = false;
+  kill() {
+    this.killed = true;
+    return true;
+  }
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+// ─── Pure builders ────────────────────────────────────────────────────────────
+
+describe("companionAllowedTools", () => {
+  it("includes the 6 lifecycle tools + proxy tools, all server-qualified", () => {
+    const allow = companionAllowedTools(companion("notes", ["notes_fetch", "notes_post"]));
+    expect(allow).toEqual([
+      "mcp__claudepanion__notes_get",
+      "mcp__claudepanion__notes_list",
+      "mcp__claudepanion__notes_update_status",
+      "mcp__claudepanion__notes_append_log",
+      "mcp__claudepanion__notes_save_artifact",
+      "mcp__claudepanion__notes_fail",
+      "mcp__claudepanion__notes_fetch",
+      "mcp__claudepanion__notes_post",
+    ]);
+  });
+
+  it("omits lifecycle tools for tool-kind companions", () => {
+    const allow = companionAllowedTools(companion("t", ["t_run"], "tool"));
+    expect(allow).toEqual(["mcp__claudepanion__t_run"]);
+  });
+});
+
+describe("buildClaudeArgs", () => {
+  const args = buildClaudeArgs({
+    prompt: "do it",
+    skillInstructions: "SKILL BODY",
+    mcpConfigPath: "/home/.claudepanion/.mcp.json",
+    allowedTools: ["mcp__claudepanion__notes_get", "mcp__claudepanion__notes_fail"],
+  });
+
+  it("runs print mode with the prompt and inlines the skill as system prompt", () => {
+    expect(args[0]).toBe("-p");
+    expect(args[1]).toBe("do it");
+    expect(args).toContain("--append-system-prompt");
+    expect(args[args.indexOf("--append-system-prompt") + 1]).toBe("SKILL BODY");
+  });
+
+  it("scopes MCP to the companion config and the allowlist", () => {
+    expect(args).toContain("--strict-mcp-config");
+    expect(args[args.indexOf("--mcp-config") + 1]).toBe("/home/.claudepanion/.mcp.json");
+    expect(args[args.indexOf("--allowedTools") + 1]).toBe(
+      "mcp__claudepanion__notes_get,mcp__claudepanion__notes_fail"
+    );
+  });
+
+  it("NEVER skips permissions", () => {
+    expect(args).not.toContain("--dangerously-skip-permissions");
+    expect(args).not.toContain("--allow-dangerously-skip-permissions");
+    expect(args).not.toContain("bypassPermissions");
+  });
+});
+
+describe("buildHeadlessPrompt", () => {
+  it("names the entity, the get tool, and the no-human constraint", () => {
+    const p = buildHeadlessPrompt("notes", "notes-abc");
+    expect(p).toContain("notes-abc");
+    expect(p).toContain("notes_get");
+    expect(p).toMatch(/NO human/);
+    expect(p).toMatch(/never pause/i);
+  });
+});
+
+// ─── Runner behaviour ─────────────────────────────────────────────────────────
+
+describe("createHeadlessRunner", () => {
+  let tmp: string;
+  let store: ReturnType<typeof createEntityStore>;
+  const registry = createRegistry([companion("notes", ["notes_fetch"])]);
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "claudepanion-headless-"));
+    store = createEntityStore(tmp);
+  });
+
+  const makeRunner = (spawnFn: SpawnFn, opts: Partial<Parameters<typeof createHeadlessRunner>[0]> = {}) =>
+    createHeadlessRunner({
+      store,
+      registry,
+      homeRoot: "/home/.claudepanion",
+      readSkill: async () => "SKILL BODY",
+      spawnFn,
+      maxConcurrent: 1,
+      ...opts,
+    });
+
+  it("spawns claude with the companion's allowlist", async () => {
+    const calls: { args: string[]; opts: any }[] = [];
+    const child = new FakeChild();
+    const spawnFn: SpawnFn = (_cmd, args, opts) => {
+      calls.push({ args, opts });
+      return child as any;
+    };
+    const e = await store.create({ id: "notes-1", companion: "notes", input: {} });
+    makeRunner(spawnFn).run(e);
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+
+    expect(calls[0].opts.cwd).toBe("/home/.claudepanion");
+    const allowIdx = calls[0].args.indexOf("--allowedTools");
+    expect(calls[0].args[allowIdx + 1]).toContain("mcp__claudepanion__notes_fetch");
+    expect(calls[0].args[allowIdx + 1]).toContain("mcp__claudepanion__notes_get");
+  });
+
+  it("does NOT fail an entity the skill already drove to completed", async () => {
+    const child = new FakeChild();
+    const spawnFn: SpawnFn = () => child as any;
+    const e = await store.create({ id: "notes-2", companion: "notes", input: {} });
+    makeRunner(spawnFn).run(e);
+    await vi.waitFor(() => expect(child.listenerCount("close")).toBe(1));
+
+    // Simulate the headless skill having finished via MCP tools.
+    await store.saveArtifact("notes", "notes-2", { summary: "s", markdown: "m" });
+    child.emit("close", 0, null);
+    await flush();
+
+    const fresh = await store.get("notes", "notes-2");
+    expect(fresh?.status).toBe("completed");
+  });
+
+  it("fails an entity whose process exits without reaching a terminal state", async () => {
+    const child = new FakeChild();
+    const spawnFn: SpawnFn = () => child as any;
+    const e = await store.create({ id: "notes-3", companion: "notes", input: {} });
+    makeRunner(spawnFn).run(e);
+    await vi.waitFor(() => expect(child.listenerCount("close")).toBe(1));
+
+    child.stderr.emit("data", Buffer.from("boom"));
+    child.emit("close", 1, null);
+    await vi.waitFor(async () => {
+      const fresh = await store.get("notes", "notes-3");
+      expect(fresh?.status).toBe("error");
+    });
+    const fresh = await store.get("notes", "notes-3");
+    expect(fresh?.errorMessage).toContain("[headless]");
+    expect(fresh?.errorMessage).toContain("boom");
+  });
+
+  it("fails the entity when the skill file can't be read", async () => {
+    const spawnFn: SpawnFn = () => new FakeChild() as any;
+    const e = await store.create({ id: "notes-4", companion: "notes", input: {} });
+    const runner = makeRunner(spawnFn, {
+      readSkill: async () => {
+        throw new Error("ENOENT");
+      },
+    });
+    runner.run(e);
+    await vi.waitFor(async () => {
+      const fresh = await store.get("notes", "notes-4");
+      expect(fresh?.status).toBe("error");
+    });
+    const fresh = await store.get("notes", "notes-4");
+    expect(fresh?.errorMessage).toContain("could not read skill");
+  });
+
+  it("honors the concurrency cap", async () => {
+    const children: FakeChild[] = [];
+    const spawnFn: SpawnFn = () => {
+      const c = new FakeChild();
+      children.push(c);
+      return c as any;
+    };
+    const e1 = await store.create({ id: "notes-5", companion: "notes", input: {} });
+    const e2 = await store.create({ id: "notes-6", companion: "notes", input: {} });
+    const runner = makeRunner(spawnFn); // maxConcurrent: 1
+
+    runner.run(e1);
+    runner.run(e2);
+    await vi.waitFor(() => expect(children).toHaveLength(1));
+    expect(runner.activeCount()).toBe(1);
+
+    // First finishes → the queued one starts.
+    children[0].emit("close", 0, null);
+    await vi.waitFor(() => expect(children).toHaveLength(2));
+  });
+});

--- a/tests/server/mcp.test.ts
+++ b/tests/server/mcp.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import { createEntityStore } from "../../src/server/entity-store";
 import { createRegistry } from "../../src/server/companion-registry";
-import { buildMcpServer } from "../../src/server/mcp";
+import { buildMcpServer, entityToolNames } from "../../src/server/mcp";
 import type { Manifest, CompanionToolDefinition } from "../../src/shared/types.js";
 import { successResult } from "../../src/shared/types.js";
 
@@ -37,6 +37,18 @@ describe("mcp server", () => {
     expect(names).toContain("x_append_log");
     expect(names).toContain("x_save_artifact");
     expect(names).toContain("x_fail");
+  });
+
+  // Drift guard: the headless runner's allowlist derives from entityToolNames(),
+  // so the lifecycle tools actually registered here MUST match it exactly.
+  it("registered lifecycle tools match entityToolNames()", () => {
+    const store = createEntityStore(tmp);
+    const registry = createRegistry([{ manifest: manifest("x"), tools: [] }]);
+    const names = new Set(buildMcpServer({ store, registry, companionsDir: tmp, snapshots: new Map() }).listToolNames());
+    for (const name of entityToolNames("x")) expect(names.has(name)).toBe(true);
+    // No extra `x_`-prefixed lifecycle-looking tool escaped the helper.
+    const lifecycle = [...names].filter((n) => n.startsWith("x_"));
+    expect(lifecycle.sort()).toEqual(entityToolNames("x").sort());
   });
 
   it("does not register generic tools for tool-kind companions", () => {


### PR DESCRIPTION
## What

Adds an opt-in **headless** execution mode for ui-kind companions. Instead of pasting a `/<slug>-companion <id>` slash command into Claude Code, the **host runs `claude -p` itself** when the form is submitted — and the artifact appears in the browser with no terminal step.

Design spec: `docs/superpowers/specs/2026-05-30-headless-companions-design.md` (committed in this branch).

## How it works

Headless is a **launch mechanism, not a second engine** — everything downstream of the spawn (entity store, MCP tools, polling, artifact) is unchanged. The only difference is *who invokes Claude*: the host instead of the human.

- The host inlines the companion's `SKILL.md` via `--append-system-prompt`, points `--mcp-config` at the companion's `.mcp.json`, and bounds the run to **only this companion's MCP tools** via `--allowedTools` + `--strict-mcp-config`.
- **No skip-permissions.** Tools outside the allowlist are denied (loud, safe). There is no escape hatch to force arbitrary `Bash`/`Write` in v1.
- Because the host constructs the whole invocation, headless **sidesteps the plugin-plumbing path** entirely (no slash command / plugin install / cwd dependency).

## Changes

| Area | Change |
|---|---|
| `src/shared/types.ts` | optional `execution?: "interactive" \| "headless"` on `Manifest` (undefined = interactive; backward-compatible, no contract bump) |
| `src/server/headless-runner.ts` (new) | spawns + supervises the run: concurrency cap, timeout, crash / exit-without-terminal → marks entity error. Pure argv + allowlist builders are unit-tested |
| `src/server/mcp.ts` | single-source the lifecycle tool names (`entityToolNames`) the allowlist derives from, with a drift-guard test |
| `src/server/api-routes.ts` + `boot.ts` | `POST /api/entities` launches the runner for headless companions only (injectable `runHeadless` dep) |
| `companions/build/*` + `skills/build-companion/SKILL.md` | execution toggle in the Build form (ui-kind) with task-shape guidance + the unattended caveat; `serializeBuildPrompt` emits the headless manifest instruction; build skill honors it |
| `src/client/pages/EntityDetail.tsx` | headless entities show a "running headlessly" hero instead of the slash-command handoff |

**Build itself stays interactive** — it writes files + runs scaffold, and its loop is conversational (describe → scaffold → look → refine). It's the *author* of the `execution` field for other companions, not a dual-mode special case.

## Tests

`npm run check` clean, `npm run build` clean, **303 tests pass**. New coverage: runner argv/allowlist/lifecycle (incl. "never skips permissions"), route dispatch (headless launches / interactive doesn't), serializer execution mode, Build form toggle, EntityDetail headless hero, mcp drift guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)